### PR TITLE
[Feat] feign client timeslot waiting 맞춰 재수정 및 일부 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.kafka:spring-kafka'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/http/reservation.http
+++ b/http/reservation.http
@@ -144,15 +144,27 @@ Content-Type: application/json
 ###
 
 ### 5. [Internal] 예약 유효성 확인
-# [플로우] 레스토랑 서비스가 체크인 가능 여부 확인 목적으로 호출 → CONFIRMED/COMPLETED 예약 존재 여부 반환
+# [플로우] 레스토랑 서비스가 체크인 가능 여부 확인 목적으로 호출 → CONFIRMED/COMPLETED 예약 존재 여부 + 예약 ID/날짜 반환
 # [데이터] userId + restaurantId 조합으로 유효 상태 예약 조회
-# [기대]   200 OK, exists=true (1번에서 예약이 생성되어 있으므로)
+# [기대]   200 OK, exists=true, reservationId 및 reservationDate 포함
 GET {{base_url}}/internal/reservations/verify?userId={{user_id}}&restaurantId={{restaurant_id}}
 
 > {%
   client.test("200 OK", function() {
     client.assert(response.status === 200, "Expected 200, got " + response.status);
   });
+  client.test("exists true", function() {
+    client.assert(response.body.data.exists === true, "Expected exists=true");
+  });
+  client.test("reservationId 존재", function() {
+    client.assert(response.body.data.reservationId != null, "Expected reservationId");
+  });
+  client.test("reservationDate 존재", function() {
+    client.assert(response.body.data.reservationDate != null, "Expected reservationDate");
+  });
+  if (response.body.data.reservationId) {
+    client.global.set("reservation_id", response.body.data.reservationId);
+  }
 %}
 
 ###

--- a/http/reservation.http
+++ b/http/reservation.http
@@ -226,18 +226,22 @@ GET {{base_url}}/internal/reservations/exists?reservationId={{reservation_id}}&u
 
 ###
 
-### 8. [Internal] 진행 중인 예약 존재 여부 확인 (체크인 후)
-# [플로우] 6번 체크인 완료 후 동일 userId로 다시 조회 → COMPLETED 상태는 CONFIRMED가 아니므로 exists=false
-# [데이터] 체크인으로 COMPLETED 전환된 예약 보유 userId
-# [기대]   200 OK, exists=false (탈퇴 가능 상태)
-GET {{base_url}}/internal/reservations/active?userId={{user_id}}
+### 8. 체크인 완료 후 예약 상태 확인
+# [플로우] 6번 체크인 완료 후 해당 예약의 상태가 COMPLETED인지 직접 확인
+# [데이터] 6번에서 체크인한 reservation_id
+# [기대]   200 OK, status=COMPLETED
+# [참고]   active 엔드포인트(userId 전체 조회)는 이전 테스트 실행에서 남은 CONFIRMED 예약이
+#          있으면 exists=true가 반환될 수 있어 신뢰성이 낮음 — 현재 예약 단건 조회로 대체
+GET {{base_url}}/api/v1/reservations/{{reservation_id}}
+X-User-Id: {{user_id}}
+X-User-Role: USER
 
 > {%
   client.test("200 OK", function() {
     client.assert(response.status === 200, "Expected 200, got " + response.status);
   });
-  client.test("exists false (체크인 후 CONFIRMED 없음)", function() {
-    client.assert(response.body.data.exists === false, "Expected exists=false");
+  client.test("status COMPLETED (체크인 완료)", function() {
+    client.assert(response.body.data.status === "COMPLETED", "Expected status=COMPLETED");
   });
 %}
 

--- a/http/reservation.http
+++ b/http/reservation.http
@@ -177,7 +177,7 @@ GET {{base_url}}/internal/reservations/active?userId={{user_id}}
 ### 6. [Internal] 체크인
 # [플로우] 5번 유효성 확인 후 레스토랑 서비스가 호출 → CONFIRMED → COMPLETED 상태 전환
 # [데이터] reservation_id + restaurantId (restaurantId 불일치 시 404)
-# [기대]   200 OK, status=COMPLETED
+# [기대]   200 OK, status=COMPLETED, visitDate 및 checkedInAt 포함
 PATCH {{base_url}}/internal/reservations/check-in
 Content-Type: application/json
 
@@ -192,6 +192,12 @@ Content-Type: application/json
   });
   client.test("status COMPLETED", function() {
     client.assert(response.body.data.status === "COMPLETED", "Expected COMPLETED");
+  });
+  client.test("visitDate 존재", function() {
+    client.assert(response.body.data.visitDate != null, "Expected visitDate");
+  });
+  client.test("checkedInAt 존재", function() {
+    client.assert(response.body.data.checkedInAt != null, "Expected checkedInAt");
   });
 %}
 

--- a/http/reservation.http
+++ b/http/reservation.http
@@ -162,9 +162,6 @@ GET {{base_url}}/internal/reservations/verify?userId={{user_id}}&restaurantId={{
   client.test("reservationDate 존재", function() {
     client.assert(response.body.data.reservationDate != null, "Expected reservationDate");
   });
-  if (response.body.data.reservationId) {
-    client.global.set("reservation_id", response.body.data.reservationId);
-  }
 %}
 
 ###

--- a/src/main/java/com/michelet/reservation/application/port/ReservationEventPort.java
+++ b/src/main/java/com/michelet/reservation/application/port/ReservationEventPort.java
@@ -1,0 +1,9 @@
+package com.michelet.reservation.application.port;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public interface ReservationEventPort {
+    void publishReservationCreated(UUID reservationId, UUID userId, UUID restaurantId,
+                                   UUID timeSlotId, LocalDate reservedDate, int guestCount);
+}

--- a/src/main/java/com/michelet/reservation/application/port/WaitingPort.java
+++ b/src/main/java/com/michelet/reservation/application/port/WaitingPort.java
@@ -1,5 +1,8 @@
 package com.michelet.reservation.application.port;
 
+import java.util.UUID;
+
 public interface WaitingPort {
     WaitingTokenResult verifyToken(String token);
+    void completeWaiting(UUID waitingId, UUID userId);
 }

--- a/src/main/java/com/michelet/reservation/application/port/WaitingTokenResult.java
+++ b/src/main/java/com/michelet/reservation/application/port/WaitingTokenResult.java
@@ -2,4 +2,4 @@ package com.michelet.reservation.application.port;
 
 import java.util.UUID;
 
-public record WaitingTokenResult(UUID userId, UUID restaurantId, boolean valid) {}
+public record WaitingTokenResult(UUID waitingId, boolean valid) {}

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandService.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandService.java
@@ -3,6 +3,7 @@ package com.michelet.reservation.application.reservation;
 import com.michelet.reservation.application.reservation.command.CancelReservationCommand;
 import com.michelet.reservation.application.reservation.command.CheckInCommand;
 import com.michelet.reservation.application.reservation.command.CreateReservationCommand;
+import com.michelet.reservation.application.reservation.command.DeleteReservationCommand;
 import com.michelet.reservation.application.reservation.command.ModifyReservationCommand;
 import com.michelet.reservation.application.reservation.result.ReservationResult;
 import com.michelet.reservation.application.reservation.result.ReservationStatusResult;
@@ -16,4 +17,6 @@ public interface ReservationCommandService {
   void cancel(CancelReservationCommand command);
 
   ReservationStatusResult checkIn(CheckInCommand command);
+
+  void delete(DeleteReservationCommand command);
 }

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
@@ -4,6 +4,7 @@ import com.michelet.common.exception.BusinessException;
 import com.michelet.reservation.application.reservation.command.CancelReservationCommand;
 import com.michelet.reservation.application.reservation.command.CheckInCommand;
 import com.michelet.reservation.application.reservation.command.CreateReservationCommand;
+import com.michelet.reservation.application.reservation.command.DeleteReservationCommand;
 import com.michelet.reservation.application.reservation.command.ModifyReservationCommand;
 import com.michelet.reservation.application.reservation.result.ReservationCourseResult;
 import com.michelet.reservation.application.reservation.result.ReservationResult;
@@ -113,6 +114,15 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
         reservationRepository.save(reservation);
 
         timeSlotPort.incrementStock(reservation.getTimeSlotId(), reservation.getGuestCount().value());
+    }
+
+    @Override
+    public void delete(DeleteReservationCommand command) {
+        Reservation reservation = findAndVerifyOwnership(command.reservationId(), command.userId(), command.userRole());
+        reservationRepository.delete(reservation.getId(), command.userId());
+        if (reservation.getStatus() == ReservationStatus.CONFIRMED) {
+            timeSlotPort.incrementStock(reservation.getTimeSlotId(), reservation.getGuestCount().value());
+        }
     }
 
     @Override

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
@@ -151,8 +151,8 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     }
 
     private void checkDuplicate(UUID userId, UUID timeSlotId, LocalDate reservedDate) {
-        if (reservationRepository.existsByUserIdAndTimeSlotIdAndReservedDateAndStatusNot(
-                userId, timeSlotId, reservedDate, ReservationStatus.CANCELLED)) {
+        if (reservationRepository.existsByUserIdAndTimeSlotIdAndReservedDateAndStatus(
+                userId, timeSlotId, reservedDate, ReservationStatus.CONFIRMED)) {
             throw new BusinessException(ReservationErrorCode.DUPLICATE_RESERVATION);
         }
     }

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
@@ -42,8 +42,8 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
 
     @Override
     public ReservationResult create(CreateReservationCommand command) {
-        // TODO: 1차 — 대기열 토큰 서명 검증 (로컬, 추후 구현)
-        // 2차 — 대기열 서비스에 토큰 유효성 확인 (userId·restaurantId 바인딩까지 검증)
+        // waiting-service가 ACTIVE 상태인지 확인 — userId·restaurantId 바인딩 검증은
+        // waiting-service API가 해당 필드를 응답에 포함할 때 추가 예정
         var tokenResult = waitingPort.verifyToken(command.waitingToken());
         if (!tokenResult.valid()) {
             throw new BusinessException(ReservationErrorCode.INVALID_WAITING_TOKEN);

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
@@ -42,9 +42,7 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
         // TODO: 1차 — 대기열 토큰 서명 검증 (로컬, 추후 구현)
         // 2차 — 대기열 서비스에 토큰 유효성 확인 (userId·restaurantId 바인딩까지 검증)
         var tokenResult = waitingPort.verifyToken(command.waitingToken());
-        if (!tokenResult.valid()
-                || !command.userId().equals(tokenResult.userId())
-                || !command.restaurantId().equals(tokenResult.restaurantId())) {
+        if (!tokenResult.valid()) {
             throw new BusinessException(ReservationErrorCode.INVALID_WAITING_TOKEN);
         }
 
@@ -66,6 +64,7 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
 
         // DB 저장 완료 후 외부 호출 — 롤백 시 Feign 미호출 보장 (단, 커밋 전 호출이므로 분산 트랜잭션 리스크 존재)
         timeSlotPort.decrementStock(saved.getTimeSlotId(), saved.getGuestCount().value());
+        waitingPort.completeWaiting(tokenResult.waitingId(), command.userId());
 
         return toResult(saved, savedCourses);
     }

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
@@ -17,6 +17,7 @@ import com.michelet.reservation.domain.repository.ReservationCourseRepository;
 import com.michelet.reservation.domain.repository.ReservationRepository;
 import com.michelet.reservation.domain.vo.GuestCount;
 import com.michelet.reservation.domain.vo.Money;
+import com.michelet.reservation.application.port.ReservationEventPort;
 import com.michelet.reservation.application.port.TimeSlotPort;
 import com.michelet.reservation.application.port.WaitingPort;
 import java.time.LocalDate;
@@ -37,6 +38,7 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     private final ReservationCourseRepository reservationCourseRepository;
     private final TimeSlotPort timeSlotPort;
     private final WaitingPort waitingPort;
+    private final ReservationEventPort reservationEventPort;
 
     @Override
     public ReservationResult create(CreateReservationCommand command) {
@@ -66,6 +68,14 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
         // DB 저장 완료 후 외부 호출 — 롤백 시 Feign 미호출 보장 (단, 커밋 전 호출이므로 분산 트랜잭션 리스크 존재)
         timeSlotPort.decrementStock(saved.getTimeSlotId(), saved.getGuestCount().value());
         waitingPort.completeWaiting(tokenResult.waitingId(), command.userId());
+        reservationEventPort.publishReservationCreated(
+                saved.getId(),
+                saved.getUserId(),
+                saved.getRestaurantId(),
+                saved.getTimeSlotId(),
+                saved.getReservedDate(),
+                saved.getGuestCount().value()
+        );
 
         return toResult(saved, savedCourses);
     }

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationQueryServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationQueryServiceImpl.java
@@ -54,9 +54,10 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
 
     @Override
     public ReservationValidityResult checkValidity(UUID userId, UUID restaurantId) {
-        boolean exists = reservationRepository.existsByUserIdAndRestaurantIdAndStatusIn(
-                userId, restaurantId, List.of(ReservationStatus.CONFIRMED, ReservationStatus.COMPLETED));
-        return exists ? ReservationValidityResult.found() : ReservationValidityResult.notFound();
+        return reservationRepository.findFirstByUserIdAndRestaurantIdAndStatusIn(
+                        userId, restaurantId, List.of(ReservationStatus.CONFIRMED, ReservationStatus.COMPLETED))
+                .map(ReservationValidityResult::found)
+                .orElseGet(ReservationValidityResult::notFound);
     }
 
     @Override

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationQueryServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationQueryServiceImpl.java
@@ -54,7 +54,7 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
 
     @Override
     public ReservationValidityResult checkValidity(UUID userId, UUID restaurantId) {
-        return reservationRepository.findFirstByUserIdAndRestaurantIdAndStatusIn(
+        return reservationRepository.findTopByUserIdAndRestaurantIdAndStatusInOrderByReservedDateDesc(
                         userId, restaurantId, List.of(ReservationStatus.CONFIRMED, ReservationStatus.COMPLETED))
                 .map(ReservationValidityResult::found)
                 .orElseGet(ReservationValidityResult::notFound);

--- a/src/main/java/com/michelet/reservation/application/reservation/command/DeleteReservationCommand.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/command/DeleteReservationCommand.java
@@ -1,0 +1,9 @@
+package com.michelet.reservation.application.reservation.command;
+
+import java.util.UUID;
+
+public record DeleteReservationCommand(
+        UUID reservationId,
+        UUID userId,
+        String userRole
+) {}

--- a/src/main/java/com/michelet/reservation/application/reservation/result/ReservationStatusResult.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/result/ReservationStatusResult.java
@@ -3,13 +3,22 @@ package com.michelet.reservation.application.reservation.result;
 import com.michelet.reservation.domain.entity.Reservation;
 import com.michelet.reservation.domain.enums.ReservationStatus;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record ReservationStatusResult(
     UUID reservationId,
-    ReservationStatus status
+    ReservationStatus status,
+    LocalDate visitDate,
+    LocalDateTime checkedInAt
 ) {
   public static ReservationStatusResult from(Reservation reservation) {
-    return new ReservationStatusResult(reservation.getId(), reservation.getStatus());
+    return new ReservationStatusResult(
+        reservation.getId(),
+        reservation.getStatus(),
+        reservation.getReservedDate(),
+        reservation.getCheckedInAt()
+    );
   }
 }

--- a/src/main/java/com/michelet/reservation/application/reservation/result/ReservationValidityResult.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/result/ReservationValidityResult.java
@@ -1,12 +1,20 @@
 package com.michelet.reservation.application.reservation.result;
 
-public record ReservationValidityResult(boolean exists) {
+import com.michelet.reservation.domain.entity.Reservation;
+import java.time.LocalDate;
+import java.util.UUID;
 
-  public static ReservationValidityResult found() {
-    return new ReservationValidityResult(true);
+public record ReservationValidityResult(
+    boolean exists,
+    UUID reservationId,
+    LocalDate reservationDate
+) {
+
+  public static ReservationValidityResult found(Reservation reservation) {
+    return new ReservationValidityResult(true, reservation.getId(), reservation.getReservedDate());
   }
 
   public static ReservationValidityResult notFound() {
-    return new ReservationValidityResult(false);
+    return new ReservationValidityResult(false, null, null);
   }
 }

--- a/src/main/java/com/michelet/reservation/common/GatewayHeaders.java
+++ b/src/main/java/com/michelet/reservation/common/GatewayHeaders.java
@@ -1,0 +1,10 @@
+package com.michelet.reservation.common;
+
+public final class GatewayHeaders {
+
+    public static final String USER_ID      = "X-User-Id";
+    public static final String USER_ROLE    = "X-User-Role";
+    public static final String WAITING_TOKEN = "X-Waiting-Token";
+
+    private GatewayHeaders() {}
+}

--- a/src/main/java/com/michelet/reservation/config/AuditorConfig.java
+++ b/src/main/java/com/michelet/reservation/config/AuditorConfig.java
@@ -17,7 +17,7 @@ public class AuditorConfig {
   @Bean
   public AuditorAware<UUID> auditorAware() {
     return () -> {
-      String userId = MDC.get("userId");
+      String userId = MDC.get(MdcKeys.USER_ID);
       if (userId == null || userId.isBlank()) {
         return Optional.of(SYSTEM_AUDITOR_ID);
       }

--- a/src/main/java/com/michelet/reservation/config/MdcKeys.java
+++ b/src/main/java/com/michelet/reservation/config/MdcKeys.java
@@ -1,0 +1,8 @@
+package com.michelet.reservation.config;
+
+public final class MdcKeys {
+
+    public static final String USER_ID = "userId";
+
+    private MdcKeys() {}
+}

--- a/src/main/java/com/michelet/reservation/config/MdcUserFilter.java
+++ b/src/main/java/com/michelet/reservation/config/MdcUserFilter.java
@@ -1,0 +1,32 @@
+package com.michelet.reservation.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class MdcUserFilter extends OncePerRequestFilter {
+
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String MDC_USER_ID_KEY = "userId";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String userId = request.getHeader(USER_ID_HEADER);
+        if (userId != null && !userId.isBlank()) {
+            MDC.put(MDC_USER_ID_KEY, userId);
+        }
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(MDC_USER_ID_KEY);
+        }
+    }
+}

--- a/src/main/java/com/michelet/reservation/config/MdcUserFilter.java
+++ b/src/main/java/com/michelet/reservation/config/MdcUserFilter.java
@@ -1,5 +1,6 @@
 package com.michelet.reservation.config;
 
+import com.michelet.reservation.common.GatewayHeaders;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,24 +14,22 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Component
 public class MdcUserFilter extends OncePerRequestFilter {
 
-    private static final String USER_ID_HEADER = "X-User-Id";
-    private static final String MDC_USER_ID_KEY = "userId";
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
                                     @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
-        String userIdHeader = request.getHeader(USER_ID_HEADER);
+        String userIdHeader = request.getHeader(GatewayHeaders.USER_ID);
         if (userIdHeader != null) {
             String userId = userIdHeader.trim();
             if (!userId.isBlank()) {
-                MDC.put(MDC_USER_ID_KEY, userId);
+                MDC.put(MdcKeys.USER_ID, userId);
             }
         }
         try {
             filterChain.doFilter(request, response);
         } finally {
-            MDC.remove(MDC_USER_ID_KEY);
+            MDC.remove(MdcKeys.USER_ID);
         }
     }
 }

--- a/src/main/java/com/michelet/reservation/config/MdcUserFilter.java
+++ b/src/main/java/com/michelet/reservation/config/MdcUserFilter.java
@@ -20,9 +20,12 @@ public class MdcUserFilter extends OncePerRequestFilter {
     protected void doFilterInternal(@NonNull HttpServletRequest request,
                                     @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
-        String userId = request.getHeader(USER_ID_HEADER);
-        if (userId != null && !userId.isBlank()) {
-            MDC.put(MDC_USER_ID_KEY, userId);
+        String userIdHeader = request.getHeader(USER_ID_HEADER);
+        if (userIdHeader != null) {
+            String userId = userIdHeader.trim();
+            if (!userId.isBlank()) {
+                MDC.put(MDC_USER_ID_KEY, userId);
+            }
         }
         try {
             filterChain.doFilter(request, response);

--- a/src/main/java/com/michelet/reservation/config/MdcUserFilter.java
+++ b/src/main/java/com/michelet/reservation/config/MdcUserFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.slf4j.MDC;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -16,9 +17,9 @@ public class MdcUserFilter extends OncePerRequestFilter {
     private static final String MDC_USER_ID_KEY = "userId";
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
         String userId = request.getHeader(USER_ID_HEADER);
         if (userId != null && !userId.isBlank()) {
             MDC.put(MDC_USER_ID_KEY, userId);

--- a/src/main/java/com/michelet/reservation/domain/entity/Reservation.java
+++ b/src/main/java/com/michelet/reservation/domain/entity/Reservation.java
@@ -31,6 +31,8 @@ public class Reservation {
 
   private LocalDateTime noshowDeadline;
 
+  private LocalDateTime checkedInAt;
+
   public static Reservation create(
       UUID userId,
       UUID restaurantId,
@@ -65,7 +67,8 @@ public class Reservation {
       ReservationStatus status,
       LocalDate cancelDeadline,
       LocalDate modifyDeadline,
-      LocalDateTime noshowDeadline
+      LocalDateTime noshowDeadline,
+      LocalDateTime checkedInAt
   ) {
     validateReconstituteInput(id,userId, restaurantId, timeSlotId, reservedDate, guestCount);
     Reservation r = new Reservation();
@@ -79,6 +82,7 @@ public class Reservation {
     r.cancelDeadline = cancelDeadline;
     r.modifyDeadline = modifyDeadline;
     r.noshowDeadline = noshowDeadline;
+    r.checkedInAt    = checkedInAt;
     return r;
   }
 
@@ -93,6 +97,7 @@ public class Reservation {
   public void complete() {
     validateTransition(ReservationStatus.CONFIRMED);
     this.status = ReservationStatus.COMPLETED;
+    this.checkedInAt = LocalDateTime.now();
   }
 
   public void markNoShow() {

--- a/src/main/java/com/michelet/reservation/domain/exception/ReservationSuccessCode.java
+++ b/src/main/java/com/michelet/reservation/domain/exception/ReservationSuccessCode.java
@@ -10,7 +10,8 @@ public enum ReservationSuccessCode implements SuccessCode {
     RESERVATION_VALIDITY_CHECKED("RESERVATION_SUCCESS_004", "예약 유효성 확인이 완료되었습니다."),
     RESERVATION_CHECKED_IN("RESERVATION_SUCCESS_005", "체크인이 완료되었습니다."),
     RESERVATION_EXISTS_CHECKED("RESERVATION_SUCCESS_006", "예약 존재 여부 확인이 완료되었습니다."),
-    RESERVATION_ACTIVE_CHECKED("RESERVATION_SUCCESS_007", "진행 중인 예약 존재 여부 확인이 완료되었습니다.");
+    RESERVATION_ACTIVE_CHECKED("RESERVATION_SUCCESS_007", "진행 중인 예약 존재 여부 확인이 완료되었습니다."),
+    RESERVATION_DELETED("RESERVATION_SUCCESS_008", "예약이 삭제되었습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/michelet/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/michelet/reservation/domain/repository/ReservationRepository.java
@@ -19,8 +19,8 @@ public interface ReservationRepository {
 
     Page<Reservation> findPageByUserIdAndStatus(UUID userId, ReservationStatus status, Pageable pageable);
 
-    boolean existsByUserIdAndTimeSlotIdAndReservedDateAndStatusNot(UUID userId, UUID timeSlotId, LocalDate reservedDate,
-                                                                   ReservationStatus status);
+    boolean existsByUserIdAndTimeSlotIdAndReservedDateAndStatus(UUID userId, UUID timeSlotId, LocalDate reservedDate,
+                                                                ReservationStatus status);
 
     boolean existsByUserIdAndRestaurantIdAndStatusIn(UUID userId, UUID restaurantId, List<ReservationStatus> statuses);
 

--- a/src/main/java/com/michelet/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/michelet/reservation/domain/repository/ReservationRepository.java
@@ -22,7 +22,7 @@ public interface ReservationRepository {
     boolean existsByUserIdAndTimeSlotIdAndReservedDateAndStatus(UUID userId, UUID timeSlotId, LocalDate reservedDate,
                                                                 ReservationStatus status);
 
-    boolean existsByUserIdAndRestaurantIdAndStatusIn(UUID userId, UUID restaurantId, List<ReservationStatus> statuses);
+    Optional<Reservation> findFirstByUserIdAndRestaurantIdAndStatusIn(UUID userId, UUID restaurantId, List<ReservationStatus> statuses);
 
     boolean existsByUserIdAndStatus(UUID userId, ReservationStatus status);
 

--- a/src/main/java/com/michelet/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/michelet/reservation/domain/repository/ReservationRepository.java
@@ -22,7 +22,7 @@ public interface ReservationRepository {
     boolean existsByUserIdAndTimeSlotIdAndReservedDateAndStatus(UUID userId, UUID timeSlotId, LocalDate reservedDate,
                                                                 ReservationStatus status);
 
-    Optional<Reservation> findFirstByUserIdAndRestaurantIdAndStatusIn(UUID userId, UUID restaurantId, List<ReservationStatus> statuses);
+    Optional<Reservation> findTopByUserIdAndRestaurantIdAndStatusInOrderByReservedDateDesc(UUID userId, UUID restaurantId, List<ReservationStatus> statuses);
 
     boolean existsByUserIdAndStatus(UUID userId, ReservationStatus status);
 

--- a/src/main/java/com/michelet/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/michelet/reservation/domain/repository/ReservationRepository.java
@@ -25,4 +25,6 @@ public interface ReservationRepository {
     boolean existsByUserIdAndRestaurantIdAndStatusIn(UUID userId, UUID restaurantId, List<ReservationStatus> statuses);
 
     boolean existsByUserIdAndStatus(UUID userId, ReservationStatus status);
+
+    void delete(UUID id, UUID deletedBy);
 }

--- a/src/main/java/com/michelet/reservation/infrastructure/client/TimeSlotClient.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/client/TimeSlotClient.java
@@ -19,7 +19,7 @@ public interface TimeSlotClient {
     /**
      * 예약 확정 시 남은 수용 인원 차감. 호출 시점: create() 저장 완료 후, modify() 날짜 변경 시 신규 날짜
      */
-    @PostMapping("/internal/v1/time-slots/{timeSlotId}/deduct")
+    @PostMapping("/internal/v1/timeslots/{timeSlotId}/deduct")
     ApiResponse<Void> decrementStock(
             @PathVariable("timeSlotId") UUID timeSlotId,
             @RequestBody TimeSlotDeductCapacityRequest request

--- a/src/main/java/com/michelet/reservation/infrastructure/client/WaitingClient.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/client/WaitingClient.java
@@ -1,6 +1,7 @@
 package com.michelet.reservation.infrastructure.client;
 
 import com.michelet.common.response.ApiResponse;
+import com.michelet.reservation.common.GatewayHeaders;
 import com.michelet.reservation.infrastructure.client.dto.WaitingTokenVerifyResponse;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -21,6 +22,6 @@ public interface WaitingClient {
     @DeleteMapping("/internal/waitings/{waitingId}/complete")
     ApiResponse<Void> completeWaiting(
             @PathVariable("waitingId") UUID waitingId,
-            @RequestHeader("X-User-Id") UUID userId
+            @RequestHeader(GatewayHeaders.USER_ID) UUID userId
     );
 }

--- a/src/main/java/com/michelet/reservation/infrastructure/client/WaitingClient.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/client/WaitingClient.java
@@ -2,16 +2,25 @@ package com.michelet.reservation.infrastructure.client;
 
 import com.michelet.common.response.ApiResponse;
 import com.michelet.reservation.infrastructure.client.dto.WaitingTokenVerifyResponse;
+import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "waiting-service", url = "${feign.waiting-service.url}")
 public interface WaitingClient {
 
-    // 1차: 예약 서비스 내 서명 검증 → 2차: 이 API로 대기열 유효성 확인
-    @GetMapping("/internal/waiting/verify-token")
+    @GetMapping("/internal/waitings/verify-token")
     ApiResponse<WaitingTokenVerifyResponse> verifyToken(
-            @RequestHeader("X-Waiting-Token") String token
+            @RequestParam("token") String token
+    );
+
+    @DeleteMapping("/internal/waitings/{waitingId}/complete")
+    ApiResponse<Void> completeWaiting(
+            @PathVariable("waitingId") UUID waitingId,
+            @RequestHeader("X-User-Id") UUID userId
     );
 }

--- a/src/main/java/com/michelet/reservation/infrastructure/client/adapter/StubTimeSlotAdapter.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/client/adapter/StubTimeSlotAdapter.java
@@ -16,11 +16,11 @@ public class StubTimeSlotAdapter implements TimeSlotPort {
 
     @Override
     public void decrementStock(UUID timeSlotId, int requiredCapacity) {
-        log.info("[STUB] decrementStock skipped — timeSlotId={}, requiredCapacity={}", timeSlotId, requiredCapacity);
+        log.debug("[STUB] decrementStock skipped — timeSlotId={}, requiredCapacity={}", timeSlotId, requiredCapacity);
     }
 
     @Override
     public void incrementStock(UUID timeSlotId, int requiredCapacity) {
-        log.info("[STUB] incrementStock skipped — timeSlotId={}, requiredCapacity={}", timeSlotId, requiredCapacity);
+        log.debug("[STUB] incrementStock skipped — timeSlotId={}, requiredCapacity={}", timeSlotId, requiredCapacity);
     }
 }

--- a/src/main/java/com/michelet/reservation/infrastructure/client/adapter/StubWaitingAdapter.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/client/adapter/StubWaitingAdapter.java
@@ -22,6 +22,6 @@ public class StubWaitingAdapter implements WaitingPort {
 
     @Override
     public void completeWaiting(UUID waitingId, UUID userId) {
-        log.info("[STUB] completeWaiting skipped — waitingId={}, userId={}", waitingId, userId);
+        log.debug("[STUB] completeWaiting skipped — waitingId={}, userId={}", waitingId, userId);
     }
 }

--- a/src/main/java/com/michelet/reservation/infrastructure/client/adapter/StubWaitingAdapter.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/client/adapter/StubWaitingAdapter.java
@@ -3,13 +3,13 @@ package com.michelet.reservation.infrastructure.client.adapter;
 import com.michelet.reservation.application.port.WaitingPort;
 import com.michelet.reservation.application.port.WaitingTokenResult;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 // local 프로파일 전용 — waiting-service 없이 테스트 가능하도록 토큰 검증을 항상 통과시킵니다.
-// X-Waiting-Token 헤더 값에서 "userId:restaurantId" 형식을 파싱하거나,
-// 형식이 맞지 않으면 env 파일의 기본 UUID로 응답합니다.
+@Slf4j
 @Primary
 @Component
 @ConditionalOnProperty(name = "waiting.stub", havingValue = "true")
@@ -17,15 +17,11 @@ public class StubWaitingAdapter implements WaitingPort {
 
     @Override
     public WaitingTokenResult verifyToken(String token) {
-        try {
-            String[] parts = token.split(":");
-            return new WaitingTokenResult(UUID.fromString(parts[0]), UUID.fromString(parts[1]), true);
-        } catch (Exception e) {
-            return new WaitingTokenResult(
-                    UUID.fromString("11111111-1111-1111-1111-111111111111"),
-                    UUID.fromString("22222222-2222-2222-2222-222222222222"),
-                    true
-            );
-        }
+        return new WaitingTokenResult(UUID.fromString("00000000-0000-0000-0000-000000000001"), true);
+    }
+
+    @Override
+    public void completeWaiting(UUID waitingId, UUID userId) {
+        log.info("[STUB] completeWaiting skipped — waitingId={}, userId={}", waitingId, userId);
     }
 }

--- a/src/main/java/com/michelet/reservation/infrastructure/client/adapter/WaitingAdapter.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/client/adapter/WaitingAdapter.java
@@ -3,6 +3,7 @@ package com.michelet.reservation.infrastructure.client.adapter;
 import com.michelet.reservation.application.port.WaitingPort;
 import com.michelet.reservation.application.port.WaitingTokenResult;
 import com.michelet.reservation.infrastructure.client.WaitingClient;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -15,6 +16,12 @@ public class WaitingAdapter implements WaitingPort {
     @Override
     public WaitingTokenResult verifyToken(String token) {
         var res = waitingClient.verifyToken(token).data();
-        return new WaitingTokenResult(res.userId(), res.restaurantId(), res.valid());
+        boolean valid = "ACTIVE".equalsIgnoreCase(res.status());
+        return new WaitingTokenResult(res.waitingId(), valid);
+    }
+
+    @Override
+    public void completeWaiting(UUID waitingId, UUID userId) {
+        waitingClient.completeWaiting(waitingId, userId);
     }
 }

--- a/src/main/java/com/michelet/reservation/infrastructure/client/dto/WaitingTokenVerifyResponse.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/client/dto/WaitingTokenVerifyResponse.java
@@ -1,9 +1,14 @@
 package com.michelet.reservation.infrastructure.client.dto;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record WaitingTokenVerifyResponse(
-    UUID userId,
-    UUID restaurantId,
-    boolean valid
+        UUID waitingId,
+        String token,
+        Long position,
+        String status,
+        LocalDateTime enteredAt,
+        LocalDateTime activatedAt,
+        Long estimatedWaitSeconds
 ) {}

--- a/src/main/java/com/michelet/reservation/infrastructure/kafka/KafkaTopics.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/kafka/KafkaTopics.java
@@ -1,0 +1,8 @@
+package com.michelet.reservation.infrastructure.kafka;
+
+public final class KafkaTopics {
+
+    public static final String RESERVATION_CREATED = "reservation.created";
+
+    private KafkaTopics() {}
+}

--- a/src/main/java/com/michelet/reservation/infrastructure/kafka/producer/ReservationEventProducer.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/kafka/producer/ReservationEventProducer.java
@@ -6,9 +6,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ReservationEventProducer implements ReservationEventPort {
@@ -23,6 +25,11 @@ public class ReservationEventProducer implements ReservationEventPort {
         ReservationCreatedEvent event = new ReservationCreatedEvent(
                 reservationId, userId, restaurantId, timeSlotId, reservedDate, guestCount, LocalDateTime.now()
         );
-        kafkaTemplate.send(TOPIC_RESERVATION_CREATED, reservationId.toString(), event);
+        kafkaTemplate.send(TOPIC_RESERVATION_CREATED, reservationId.toString(), event)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.warn("[Kafka] reservation.created 발행 실패 — reservationId={}, cause={}", reservationId, ex.getMessage());
+                    }
+                });
     }
 }

--- a/src/main/java/com/michelet/reservation/infrastructure/kafka/producer/ReservationEventProducer.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/kafka/producer/ReservationEventProducer.java
@@ -1,5 +1,28 @@
 package com.michelet.reservation.infrastructure.kafka.producer;
 
-public class ReservationEventProducer {
+import com.michelet.reservation.application.port.ReservationEventPort;
+import com.michelet.reservation.infrastructure.kafka.event.publish.ReservationCreatedEvent;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
 
+@Component
+@RequiredArgsConstructor
+public class ReservationEventProducer implements ReservationEventPort {
+
+    private static final String TOPIC_RESERVATION_CREATED = "reservation.created";
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Override
+    public void publishReservationCreated(UUID reservationId, UUID userId, UUID restaurantId,
+                                          UUID timeSlotId, LocalDate reservedDate, int guestCount) {
+        ReservationCreatedEvent event = new ReservationCreatedEvent(
+                reservationId, userId, restaurantId, timeSlotId, reservedDate, guestCount, LocalDateTime.now()
+        );
+        kafkaTemplate.send(TOPIC_RESERVATION_CREATED, reservationId.toString(), event);
+    }
 }

--- a/src/main/java/com/michelet/reservation/infrastructure/kafka/producer/ReservationEventProducer.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/kafka/producer/ReservationEventProducer.java
@@ -1,6 +1,7 @@
 package com.michelet.reservation.infrastructure.kafka.producer;
 
 import com.michelet.reservation.application.port.ReservationEventPort;
+import com.michelet.reservation.infrastructure.kafka.KafkaTopics;
 import com.michelet.reservation.infrastructure.kafka.event.publish.ReservationCreatedEvent;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -15,7 +16,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ReservationEventProducer implements ReservationEventPort {
 
-    private static final String TOPIC_RESERVATION_CREATED = "reservation.created";
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
@@ -25,7 +25,7 @@ public class ReservationEventProducer implements ReservationEventPort {
         ReservationCreatedEvent event = new ReservationCreatedEvent(
                 reservationId, userId, restaurantId, timeSlotId, reservedDate, guestCount, LocalDateTime.now()
         );
-        kafkaTemplate.send(TOPIC_RESERVATION_CREATED, reservationId.toString(), event)
+        kafkaTemplate.send(KafkaTopics.RESERVATION_CREATED, reservationId.toString(), event)
                 .whenComplete((result, ex) -> {
                     if (ex != null) {
                         log.warn("[Kafka] reservation.created 발행 실패 — reservationId={}, cause={}", reservationId, ex.getMessage());

--- a/src/main/java/com/michelet/reservation/infrastructure/kafka/producer/StubReservationEventAdapter.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/kafka/producer/StubReservationEventAdapter.java
@@ -1,0 +1,23 @@
+package com.michelet.reservation.infrastructure.kafka.producer;
+
+import com.michelet.reservation.application.port.ReservationEventPort;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+// local 프로파일 전용 — Kafka 없이 테스트 가능하도록 이벤트 발행을 no-op으로 처리합니다.
+@Slf4j
+@Primary
+@Component
+@ConditionalOnProperty(name = "kafka.stub", havingValue = "true")
+public class StubReservationEventAdapter implements ReservationEventPort {
+
+    @Override
+    public void publishReservationCreated(UUID reservationId, UUID userId, UUID restaurantId,
+                                          UUID timeSlotId, LocalDate reservedDate, int guestCount) {
+        log.info("[STUB] publishReservationCreated skipped — reservationId={}", reservationId);
+    }
+}

--- a/src/main/java/com/michelet/reservation/infrastructure/kafka/producer/StubReservationEventAdapter.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/kafka/producer/StubReservationEventAdapter.java
@@ -18,6 +18,6 @@ public class StubReservationEventAdapter implements ReservationEventPort {
     @Override
     public void publishReservationCreated(UUID reservationId, UUID userId, UUID restaurantId,
                                           UUID timeSlotId, LocalDate reservedDate, int guestCount) {
-        log.info("[STUB] publishReservationCreated skipped — reservationId={}", reservationId);
+        log.debug("[STUB] publishReservationCreated skipped — reservationId={}", reservationId);
     }
 }

--- a/src/main/java/com/michelet/reservation/infrastructure/reservation/ReservationJpaRepository.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/reservation/ReservationJpaRepository.java
@@ -54,10 +54,11 @@ public class ReservationJpaRepository implements ReservationRepository {
     }
 
     @Override
-    public boolean existsByUserIdAndRestaurantIdAndStatusIn(
+    public Optional<Reservation> findFirstByUserIdAndRestaurantIdAndStatusIn(
             UUID userId, UUID restaurantId, List<ReservationStatus> statuses
     ) {
-        return jpaStore.existsByUserIdAndRestaurantIdAndStatusIn(userId, restaurantId, statuses);
+        return jpaStore.findFirstByUserIdAndRestaurantIdAndStatusIn(userId, restaurantId, statuses)
+                .map(ReservationMapper::toDomain);
     }
 
     @Override

--- a/src/main/java/com/michelet/reservation/infrastructure/reservation/ReservationJpaRepository.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/reservation/ReservationJpaRepository.java
@@ -46,10 +46,10 @@ public class ReservationJpaRepository implements ReservationRepository {
     }
 
     @Override
-    public boolean existsByUserIdAndTimeSlotIdAndReservedDateAndStatusNot(
+    public boolean existsByUserIdAndTimeSlotIdAndReservedDateAndStatus(
             UUID userId, UUID timeSlotId, LocalDate reservedDate, ReservationStatus status
     ) {
-        return jpaStore.existsByUserIdAndTimeSlotIdAndReservedDateAndStatusNot(userId, timeSlotId, reservedDate,
+        return jpaStore.existsByUserIdAndTimeSlotIdAndReservedDateAndStatus(userId, timeSlotId, reservedDate,
                 status);
     }
 

--- a/src/main/java/com/michelet/reservation/infrastructure/reservation/ReservationJpaRepository.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/reservation/ReservationJpaRepository.java
@@ -54,10 +54,10 @@ public class ReservationJpaRepository implements ReservationRepository {
     }
 
     @Override
-    public Optional<Reservation> findFirstByUserIdAndRestaurantIdAndStatusIn(
+    public Optional<Reservation> findTopByUserIdAndRestaurantIdAndStatusInOrderByReservedDateDesc(
             UUID userId, UUID restaurantId, List<ReservationStatus> statuses
     ) {
-        return jpaStore.findFirstByUserIdAndRestaurantIdAndStatusIn(userId, restaurantId, statuses)
+        return jpaStore.findTopByUserIdAndRestaurantIdAndStatusInOrderByReservedDateDesc(userId, restaurantId, statuses)
                 .map(ReservationMapper::toDomain);
     }
 

--- a/src/main/java/com/michelet/reservation/infrastructure/reservation/ReservationJpaRepository.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/reservation/ReservationJpaRepository.java
@@ -64,4 +64,12 @@ public class ReservationJpaRepository implements ReservationRepository {
     public boolean existsByUserIdAndStatus(UUID userId, ReservationStatus status) {
         return jpaStore.existsByUserIdAndStatus(userId, status);
     }
+
+    @Override
+    public void delete(UUID id, UUID deletedBy) {
+        jpaStore.findById(id).ifPresent(entity -> {
+            entity.softDelete(deletedBy);
+            jpaStore.save(entity);
+        });
+    }
 }

--- a/src/main/java/com/michelet/reservation/infrastructure/reservation/ReservationJpaStore.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/reservation/ReservationJpaStore.java
@@ -4,6 +4,7 @@ import com.michelet.reservation.domain.enums.ReservationStatus;
 import com.michelet.reservation.infrastructure.reservation.entity.ReservationJpaEntity;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,7 +20,7 @@ public interface ReservationJpaStore extends JpaRepository<ReservationJpaEntity,
     boolean existsByUserIdAndTimeSlotIdAndReservedDateAndStatus(UUID userId, UUID timeSlotId, LocalDate reservedDate,
                                                                ReservationStatus status);
 
-    boolean existsByUserIdAndRestaurantIdAndStatusIn(UUID userId, UUID restaurantId, List<ReservationStatus> statuses);
+    Optional<ReservationJpaEntity> findFirstByUserIdAndRestaurantIdAndStatusIn(UUID userId, UUID restaurantId, List<ReservationStatus> statuses);
 
     boolean existsByUserIdAndStatus(UUID userId, ReservationStatus status);
 }

--- a/src/main/java/com/michelet/reservation/infrastructure/reservation/ReservationJpaStore.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/reservation/ReservationJpaStore.java
@@ -16,8 +16,8 @@ public interface ReservationJpaStore extends JpaRepository<ReservationJpaEntity,
     Page<ReservationJpaEntity> findAllByUserIdAndStatus(UUID userId, ReservationStatus status, Pageable pageable);
 
 
-    boolean existsByUserIdAndTimeSlotIdAndReservedDateAndStatusNot(UUID userId, UUID timeSlotId, LocalDate reservedDate,
-                                                                   ReservationStatus status);
+    boolean existsByUserIdAndTimeSlotIdAndReservedDateAndStatus(UUID userId, UUID timeSlotId, LocalDate reservedDate,
+                                                               ReservationStatus status);
 
     boolean existsByUserIdAndRestaurantIdAndStatusIn(UUID userId, UUID restaurantId, List<ReservationStatus> statuses);
 

--- a/src/main/java/com/michelet/reservation/infrastructure/reservation/ReservationJpaStore.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/reservation/ReservationJpaStore.java
@@ -20,7 +20,7 @@ public interface ReservationJpaStore extends JpaRepository<ReservationJpaEntity,
     boolean existsByUserIdAndTimeSlotIdAndReservedDateAndStatus(UUID userId, UUID timeSlotId, LocalDate reservedDate,
                                                                ReservationStatus status);
 
-    Optional<ReservationJpaEntity> findFirstByUserIdAndRestaurantIdAndStatusIn(UUID userId, UUID restaurantId, List<ReservationStatus> statuses);
+    Optional<ReservationJpaEntity> findTopByUserIdAndRestaurantIdAndStatusInOrderByReservedDateDesc(UUID userId, UUID restaurantId, List<ReservationStatus> statuses);
 
     boolean existsByUserIdAndStatus(UUID userId, ReservationStatus status);
 }

--- a/src/main/java/com/michelet/reservation/infrastructure/reservation/entity/ReservationCourseJpaEntity.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/reservation/entity/ReservationCourseJpaEntity.java
@@ -8,11 +8,13 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.util.UUID;
 
 @Entity
 @Table(name = "p_reservation_courses")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReservationCourseJpaEntity  extends BaseJpaEntity {

--- a/src/main/java/com/michelet/reservation/infrastructure/reservation/entity/ReservationJpaEntity.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/reservation/entity/ReservationJpaEntity.java
@@ -56,10 +56,14 @@ public class ReservationJpaEntity  extends BaseJpaEntity {
   @Column(name = "noshow_deadline", nullable = false)
   private LocalDateTime noshowDeadline;
 
+  @Column(name = "checked_in_at")
+  private LocalDateTime checkedInAt;
+
   public static ReservationJpaEntity of(
       UUID id, UUID userId, UUID restaurantId, UUID timeSlotId,
       LocalDate reservedDate, int guestCount, ReservationStatus status,
-      LocalDate cancelDeadline, LocalDate modifyDeadline, LocalDateTime noshowDeadline
+      LocalDate cancelDeadline, LocalDate modifyDeadline, LocalDateTime noshowDeadline,
+      LocalDateTime checkedInAt
   ) {
     ReservationJpaEntity e = new ReservationJpaEntity();
     e.id             = id;
@@ -72,6 +76,7 @@ public class ReservationJpaEntity  extends BaseJpaEntity {
     e.cancelDeadline = cancelDeadline;
     e.modifyDeadline = modifyDeadline;
     e.noshowDeadline = noshowDeadline;
+    e.checkedInAt    = checkedInAt;
     return e;
   }
 

--- a/src/main/java/com/michelet/reservation/infrastructure/reservation/entity/ReservationJpaEntity.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/reservation/entity/ReservationJpaEntity.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -18,6 +19,7 @@ import java.util.UUID;
 
 @Entity
 @Table(name = "p_reservations")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReservationJpaEntity  extends BaseJpaEntity {

--- a/src/main/java/com/michelet/reservation/infrastructure/reservation/mapper/ReservationMapper.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/reservation/mapper/ReservationMapper.java
@@ -14,7 +14,8 @@ public class ReservationMapper {
         domain.getId(), domain.getUserId(), domain.getRestaurantId(),
         domain.getTimeSlotId(), domain.getReservedDate(),
         domain.getGuestCount().value(), domain.getStatus(),
-        domain.getCancelDeadline(), domain.getModifyDeadline(), domain.getNoshowDeadline()
+        domain.getCancelDeadline(), domain.getModifyDeadline(), domain.getNoshowDeadline(),
+        domain.getCheckedInAt()
     );
     if (domain.isNew()) {
       entity.markNew();
@@ -27,7 +28,8 @@ public class ReservationMapper {
         entity.getId(), entity.getUserId(), entity.getRestaurantId(),
         entity.getTimeSlotId(), entity.getReservedDate(),
         GuestCount.of(entity.getGuestCount()), entity.getStatus(),
-        entity.getCancelDeadline(), entity.getModifyDeadline(), entity.getNoshowDeadline()
+        entity.getCancelDeadline(), entity.getModifyDeadline(), entity.getNoshowDeadline(),
+        entity.getCheckedInAt()
     );
   }
 }

--- a/src/main/java/com/michelet/reservation/presentation/reservation/ReservationController.java
+++ b/src/main/java/com/michelet/reservation/presentation/reservation/ReservationController.java
@@ -5,6 +5,7 @@ import com.michelet.reservation.application.reservation.ReservationCommandServic
 import com.michelet.reservation.domain.exception.ReservationSuccessCode;
 import com.michelet.reservation.application.reservation.ReservationQueryService;
 import com.michelet.reservation.application.reservation.command.CreateReservationCommand;
+import com.michelet.reservation.application.reservation.command.DeleteReservationCommand;
 import com.michelet.reservation.application.reservation.command.ModifyReservationCommand;
 import com.michelet.reservation.domain.enums.ReservationStatus;
 import com.michelet.reservation.presentation.reservation.dto.request.CreateReservationRequest;
@@ -19,6 +20,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -82,6 +84,17 @@ public class ReservationController {
         queryService.getDetail(userId, userRole, reservationId)
     );
     return ApiResponse.ok(ReservationSuccessCode.RESERVATION_FETCHED, response);
+  }
+
+  /* 권한: USER·OWNER·MASTER */
+  @DeleteMapping("/{reservationId}")
+  public ApiResponse<Void> delete(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") String userRole,
+      @PathVariable UUID reservationId
+  ) {
+    commandService.delete(new DeleteReservationCommand(reservationId, userId, userRole));
+    return ApiResponse.ok(ReservationSuccessCode.RESERVATION_DELETED, null);
   }
 
   /* 권한: USER·OWNER·MASTER — 조건: CONFIRMED + modify_deadline 이내 */

--- a/src/main/java/com/michelet/reservation/presentation/reservation/ReservationController.java
+++ b/src/main/java/com/michelet/reservation/presentation/reservation/ReservationController.java
@@ -1,6 +1,7 @@
 package com.michelet.reservation.presentation.reservation;
 
 import com.michelet.common.response.ApiResponse;
+import com.michelet.reservation.common.GatewayHeaders;
 import com.michelet.reservation.application.reservation.ReservationCommandService;
 import com.michelet.reservation.domain.exception.ReservationSuccessCode;
 import com.michelet.reservation.application.reservation.ReservationQueryService;
@@ -44,9 +45,9 @@ public class ReservationController {
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
   public ApiResponse<ReservationResponse> create(
-      @RequestHeader("X-User-Id") UUID userId,
-      @RequestHeader("X-User-Role") String userRole,
-      @RequestHeader("X-Waiting-Token") String waitingToken,
+      @RequestHeader(GatewayHeaders.USER_ID) UUID userId,
+      @RequestHeader(GatewayHeaders.USER_ROLE) String userRole,
+      @RequestHeader(GatewayHeaders.WAITING_TOKEN) String waitingToken,
       @RequestBody @Valid CreateReservationRequest request
   ) {
     List<CreateReservationCommand.CourseItem> courses = request.courses().stream()
@@ -64,7 +65,7 @@ public class ReservationController {
   /* 권한: USER */
   @GetMapping
   public ApiResponse<Page<ReservationSummaryResponse>> getMyReservations(
-      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader(GatewayHeaders.USER_ID) UUID userId,
       @RequestParam(required = false) ReservationStatus status,
       @PageableDefault(size = 10) Pageable pageable
   ) {
@@ -76,8 +77,8 @@ public class ReservationController {
   /* 권한: USER·OWNER·MASTER */
   @GetMapping("/{reservationId}")
   public ApiResponse<ReservationResponse> getReservation(
-      @RequestHeader("X-User-Id") UUID userId,
-      @RequestHeader("X-User-Role") String userRole,
+      @RequestHeader(GatewayHeaders.USER_ID) UUID userId,
+      @RequestHeader(GatewayHeaders.USER_ROLE) String userRole,
       @PathVariable UUID reservationId
   ) {
     ReservationResponse response = ReservationResponse.from(
@@ -89,8 +90,8 @@ public class ReservationController {
   /* 권한: USER·OWNER·MASTER */
   @DeleteMapping("/{reservationId}")
   public ApiResponse<Void> delete(
-      @RequestHeader("X-User-Id") UUID userId,
-      @RequestHeader("X-User-Role") String userRole,
+      @RequestHeader(GatewayHeaders.USER_ID) UUID userId,
+      @RequestHeader(GatewayHeaders.USER_ROLE) String userRole,
       @PathVariable UUID reservationId
   ) {
     commandService.delete(new DeleteReservationCommand(reservationId, userId, userRole));
@@ -100,8 +101,8 @@ public class ReservationController {
   /* 권한: USER·OWNER·MASTER — 조건: CONFIRMED + modify_deadline 이내 */
   @PatchMapping("/{reservationId}")
   public ApiResponse<ReservationResponse> modify(
-      @RequestHeader("X-User-Id") UUID userId,
-      @RequestHeader("X-User-Role") String userRole,
+      @RequestHeader(GatewayHeaders.USER_ID) UUID userId,
+      @RequestHeader(GatewayHeaders.USER_ROLE) String userRole,
       @PathVariable UUID reservationId,
       @RequestBody @Valid ModifyReservationRequest request
   ) {

--- a/src/main/java/com/michelet/reservation/presentation/reservation/dto/response/ReservationStatusResponse.java
+++ b/src/main/java/com/michelet/reservation/presentation/reservation/dto/response/ReservationStatusResponse.java
@@ -3,13 +3,22 @@ package com.michelet.reservation.presentation.reservation.dto.response;
 import com.michelet.reservation.application.reservation.result.ReservationStatusResult;
 import com.michelet.reservation.domain.enums.ReservationStatus;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record ReservationStatusResponse(
     UUID reservationId,
-    ReservationStatus status
+    ReservationStatus status,
+    LocalDate visitDate,
+    LocalDateTime checkedInAt
 ) {
   public static ReservationStatusResponse from(ReservationStatusResult result) {
-    return new ReservationStatusResponse(result.reservationId(), result.status());
+    return new ReservationStatusResponse(
+        result.reservationId(),
+        result.status(),
+        result.visitDate(),
+        result.checkedInAt()
+    );
   }
 }

--- a/src/main/java/com/michelet/reservation/presentation/reservation/dto/response/ReservationValidityResponse.java
+++ b/src/main/java/com/michelet/reservation/presentation/reservation/dto/response/ReservationValidityResponse.java
@@ -1,10 +1,16 @@
 package com.michelet.reservation.presentation.reservation.dto.response;
 
 import com.michelet.reservation.application.reservation.result.ReservationValidityResult;
+import java.time.LocalDate;
+import java.util.UUID;
 
-public record ReservationValidityResponse(boolean exists) {
+public record ReservationValidityResponse(
+    boolean exists,
+    UUID reservationId,
+    LocalDate reservationDate
+) {
 
   public static ReservationValidityResponse from(ReservationValidityResult result) {
-    return new ReservationValidityResponse(result.exists());
+    return new ReservationValidityResponse(result.exists(), result.reservationId(), result.reservationDate());
   }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -3,3 +3,6 @@ waiting:
 
 timeslot:
   stub: true
+
+kafka:
+  stub: true

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,3 +1,7 @@
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+
 waiting:
   stub: true
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,8 +23,13 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
 
-  #  kafka:
-  #    bootstrap-servers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
+  kafka:
+    bootstrap-servers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false
 
   cloud:
     config:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,7 +24,7 @@ spring:
       port: ${REDIS_PORT:6379}
 
   kafka:
-    bootstrap-servers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
+    bootstrap-servers: ${KAFKA_HOST}:${KAFKA_PORT}
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/test/java/com/michelet/reservation/ReservationServiceApplicationTests.java
+++ b/src/test/java/com/michelet/reservation/ReservationServiceApplicationTests.java
@@ -4,8 +4,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(properties = {
-        "eureka.client.enabled=false"
-        }) // eureka client를 끄는 이유는, 테스트 시 eureka server가 켜져 있지 않아서 발생하는 문제를 방지하기 위함입니다. 실제로 eureka server가 켜져 있다면, 이 설정을 제거해도 됩니다.
+        "eureka.client.enabled=false",
+        "spring.kafka.bootstrap-servers=localhost:9092"
+})
 class ReservationServiceApplicationTests {
 
 	@Test

--- a/src/test/java/com/michelet/reservation/application/reservation/ReservationCommandServiceTest.java
+++ b/src/test/java/com/michelet/reservation/application/reservation/ReservationCommandServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.michelet.common.exception.BusinessException;
+import com.michelet.reservation.application.port.ReservationEventPort;
 import com.michelet.reservation.application.port.TimeSlotPort;
 import com.michelet.reservation.application.port.WaitingPort;
 import com.michelet.reservation.application.port.WaitingTokenResult;
@@ -52,6 +53,8 @@ class ReservationCommandServiceTest {
     TimeSlotPort timeSlotPort;
     @Mock
     WaitingPort waitingPort;
+    @Mock
+    ReservationEventPort reservationEventPort;
 
     @InjectMocks
     ReservationCommandServiceImpl commandService;
@@ -109,7 +112,7 @@ class ReservationCommandServiceTest {
         void stubDefaults() {
             when(waitingPort.verifyToken(anyString()))
                     .thenReturn(new WaitingTokenResult(waitingId, true));
-            lenient().when(reservationRepository.existsByUserIdAndTimeSlotIdAndReservedDateAndStatusNot(
+            lenient().when(reservationRepository.existsByUserIdAndTimeSlotIdAndReservedDateAndStatus(
                     any(), any(), any(), any())).thenReturn(false);
         }
 
@@ -136,7 +139,7 @@ class ReservationCommandServiceTest {
 
         @Test
         void 중복_예약이_있으면_예외를_던진다() {
-            when(reservationRepository.existsByUserIdAndTimeSlotIdAndReservedDateAndStatusNot(
+            when(reservationRepository.existsByUserIdAndTimeSlotIdAndReservedDateAndStatus(
                     any(), any(), any(), any())).thenReturn(true);
 
             assertThatThrownBy(() -> commandService.create(createCommand()))
@@ -278,7 +281,7 @@ class ReservationCommandServiceTest {
             Reservation reservation = confirmedReservation();
             when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));
             UUID newSlotId = UUID.randomUUID();
-            when(reservationRepository.existsByUserIdAndTimeSlotIdAndReservedDateAndStatusNot(
+            when(reservationRepository.existsByUserIdAndTimeSlotIdAndReservedDateAndStatus(
                     eq(userId), eq(newSlotId), eq(futureDate), any())).thenReturn(true);
 
             assertThatThrownBy(() -> commandService.modify(new ModifyReservationCommand(

--- a/src/test/java/com/michelet/reservation/application/reservation/ReservationCommandServiceTest.java
+++ b/src/test/java/com/michelet/reservation/application/reservation/ReservationCommandServiceTest.java
@@ -68,7 +68,7 @@ class ReservationCommandServiceTest {
                 reservationId, userId, restaurantId, timeSlotId,
                 futureDate, GuestCount.of(2), ReservationStatus.CONFIRMED,
                 futureDate.minusDays(2), futureDate.minusDays(2),
-                LocalDateTime.of(futureDate, slotStartTime).plusMinutes(30)
+                LocalDateTime.of(futureDate, slotStartTime).plusMinutes(30), null
         );
     }
 
@@ -80,7 +80,7 @@ class ReservationCommandServiceTest {
                 reservationId, userId, restaurantId, timeSlotId,
                 nearDate, GuestCount.of(2), ReservationStatus.CONFIRMED,
                 passedDeadline, passedDeadline,
-                LocalDateTime.of(nearDate, slotStartTime).plusMinutes(30)
+                LocalDateTime.of(nearDate, slotStartTime).plusMinutes(30), null
         );
     }
 
@@ -250,7 +250,7 @@ class ReservationCommandServiceTest {
                     reservationId, userId, restaurantId, timeSlotId,
                     futureDate, GuestCount.of(2), ReservationStatus.CANCELLED,
                     futureDate.minusDays(2), futureDate.minusDays(2),
-                    LocalDateTime.of(futureDate, slotStartTime).plusMinutes(30)
+                    LocalDateTime.of(futureDate, slotStartTime).plusMinutes(30), null
             );
             when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));
 
@@ -332,7 +332,7 @@ class ReservationCommandServiceTest {
                     reservationId, userId, restaurantId, timeSlotId,
                     futureDate, GuestCount.of(2), ReservationStatus.COMPLETED,
                     futureDate.minusDays(2), futureDate.minusDays(2),
-                    LocalDateTime.of(futureDate, slotStartTime).plusMinutes(30)
+                    LocalDateTime.of(futureDate, slotStartTime).plusMinutes(30), null
             );
             when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));
 
@@ -398,7 +398,7 @@ class ReservationCommandServiceTest {
                     reservationId, userId, restaurantId, timeSlotId,
                     futureDate, GuestCount.of(2), ReservationStatus.CANCELLED,
                     futureDate.minusDays(2), futureDate.minusDays(2),
-                    LocalDateTime.of(futureDate, slotStartTime).plusMinutes(30)
+                    LocalDateTime.of(futureDate, slotStartTime).plusMinutes(30), null
             );
             when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));
 

--- a/src/test/java/com/michelet/reservation/application/reservation/ReservationCommandServiceTest.java
+++ b/src/test/java/com/michelet/reservation/application/reservation/ReservationCommandServiceTest.java
@@ -103,49 +103,30 @@ class ReservationCommandServiceTest {
     @Nested
     class Create {
 
+        final UUID waitingId = UUID.randomUUID();
+
         @BeforeEach
         void stubDefaults() {
             when(waitingPort.verifyToken(anyString()))
-                    .thenReturn(new WaitingTokenResult(userId, restaurantId, true));
+                    .thenReturn(new WaitingTokenResult(waitingId, true));
             lenient().when(reservationRepository.existsByUserIdAndTimeSlotIdAndReservedDateAndStatusNot(
                     any(), any(), any(), any())).thenReturn(false);
         }
 
         @Test
-        void 정상_생성_시_예약이_저장되고_재고가_차감된다() {
+        void 정상_생성_시_예약이_저장되고_재고가_차감되고_대기열이_완료된다() {
             ReservationResult result = commandService.create(createCommand());
 
             assertThat(result).isNotNull();
             verify(reservationRepository).save(any(Reservation.class));
             verify(timeSlotPort).decrementStock(eq(timeSlotId), eq(2));
+            verify(waitingPort).completeWaiting(eq(waitingId), eq(userId));
         }
 
         @Test
         void 토큰이_유효하지_않으면_예외를_던진다() {
             when(waitingPort.verifyToken(anyString()))
-                    .thenReturn(new WaitingTokenResult(userId, restaurantId, false));
-
-            assertThatThrownBy(() -> commandService.create(createCommand()))
-                    .isInstanceOf(BusinessException.class)
-                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
-                            .isEqualTo(ReservationErrorCode.INVALID_WAITING_TOKEN.getCode()));
-        }
-
-        @Test
-        void 토큰의_userId가_불일치하면_예외를_던진다() {
-            when(waitingPort.verifyToken(anyString()))
-                    .thenReturn(new WaitingTokenResult(UUID.randomUUID(), restaurantId, true));
-
-            assertThatThrownBy(() -> commandService.create(createCommand()))
-                    .isInstanceOf(BusinessException.class)
-                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
-                            .isEqualTo(ReservationErrorCode.INVALID_WAITING_TOKEN.getCode()));
-        }
-
-        @Test
-        void 토큰의_restaurantId가_불일치하면_예외를_던진다() {
-            when(waitingPort.verifyToken(anyString()))
-                    .thenReturn(new WaitingTokenResult(userId, UUID.randomUUID(), true));
+                    .thenReturn(new WaitingTokenResult(waitingId, false));
 
             assertThatThrownBy(() -> commandService.create(createCommand()))
                     .isInstanceOf(BusinessException.class)

--- a/src/test/java/com/michelet/reservation/application/reservation/ReservationCommandServiceTest.java
+++ b/src/test/java/com/michelet/reservation/application/reservation/ReservationCommandServiceTest.java
@@ -19,6 +19,7 @@ import com.michelet.reservation.application.port.WaitingTokenResult;
 import com.michelet.reservation.application.reservation.command.CancelReservationCommand;
 import com.michelet.reservation.application.reservation.command.CheckInCommand;
 import com.michelet.reservation.application.reservation.command.CreateReservationCommand;
+import com.michelet.reservation.application.reservation.command.DeleteReservationCommand;
 import com.michelet.reservation.application.reservation.command.ModifyReservationCommand;
 import com.michelet.reservation.application.reservation.result.ReservationResult;
 import com.michelet.reservation.domain.entity.Reservation;
@@ -124,6 +125,8 @@ class ReservationCommandServiceTest {
             verify(reservationRepository).save(any(Reservation.class));
             verify(timeSlotPort).decrementStock(eq(timeSlotId), eq(2));
             verify(waitingPort).completeWaiting(eq(waitingId), eq(userId));
+            verify(reservationEventPort).publishReservationCreated(
+                    any(), eq(userId), eq(restaurantId), eq(timeSlotId), eq(futureDate), eq(2));
         }
 
         @Test
@@ -356,6 +359,65 @@ class ReservationCommandServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ReservationErrorCode.CANCEL_DEADLINE_EXCEEDED.getCode()));
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void CONFIRMED_예약_삭제_시_재고를_복구한다() {
+            Reservation reservation = confirmedReservation();
+            when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));
+
+            commandService.delete(new DeleteReservationCommand(reservationId, userId, "USER"));
+
+            verify(reservationRepository).delete(eq(reservationId), eq(userId));
+            verify(timeSlotPort).incrementStock(eq(timeSlotId), eq(2));
+        }
+
+        @Test
+        void CANCELLED_예약_삭제_시_재고를_복구하지_않는다() {
+            Reservation reservation = Reservation.reconstitute(
+                    reservationId, userId, restaurantId, timeSlotId,
+                    futureDate, GuestCount.of(2), ReservationStatus.CANCELLED,
+                    futureDate.minusDays(2), futureDate.minusDays(2),
+                    LocalDateTime.of(futureDate, slotStartTime).plusMinutes(30), null
+            );
+            when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));
+
+            commandService.delete(new DeleteReservationCommand(reservationId, userId, "USER"));
+
+            verify(reservationRepository).delete(eq(reservationId), eq(userId));
+            verify(timeSlotPort, never()).incrementStock(any(), anyInt());
+        }
+
+        @Test
+        void COMPLETED_예약_삭제_시_재고를_복구하지_않는다() {
+            Reservation reservation = Reservation.reconstitute(
+                    reservationId, userId, restaurantId, timeSlotId,
+                    futureDate, GuestCount.of(2), ReservationStatus.COMPLETED,
+                    futureDate.minusDays(2), futureDate.minusDays(2),
+                    LocalDateTime.of(futureDate, slotStartTime).plusMinutes(30), null
+            );
+            when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));
+
+            commandService.delete(new DeleteReservationCommand(reservationId, userId, "USER"));
+
+            verify(reservationRepository).delete(eq(reservationId), eq(userId));
+            verify(timeSlotPort, never()).incrementStock(any(), anyInt());
+        }
+
+        @Test
+        void 소유자가_아니면_예외를_던진다() {
+            Reservation reservation = confirmedReservation();
+            when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));
+
+            assertThatThrownBy(() ->
+                    commandService.delete(new DeleteReservationCommand(reservationId, UUID.randomUUID(), "USER")))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.RESERVATION_NOT_FOUND.getCode()));
         }
     }
 

--- a/src/test/java/com/michelet/reservation/application/reservation/ReservationQueryServiceTest.java
+++ b/src/test/java/com/michelet/reservation/application/reservation/ReservationQueryServiceTest.java
@@ -136,7 +136,7 @@ class ReservationQueryServiceTest {
         @Test
         void CONFIRMED_또는_COMPLETED_예약이_있으면_예약_정보를_반환한다() {
             Reservation reservation = confirmedReservation();
-            when(reservationRepository.findFirstByUserIdAndRestaurantIdAndStatusIn(
+            when(reservationRepository.findTopByUserIdAndRestaurantIdAndStatusInOrderByReservedDateDesc(
                     eq(userId), eq(restaurantId),
                     eq(List.of(ReservationStatus.CONFIRMED, ReservationStatus.COMPLETED))))
                     .thenReturn(Optional.of(reservation));
@@ -150,7 +150,7 @@ class ReservationQueryServiceTest {
 
         @Test
         void 해당_예약이_없으면_exists_false_이고_나머지_필드는_null이다() {
-            when(reservationRepository.findFirstByUserIdAndRestaurantIdAndStatusIn(
+            when(reservationRepository.findTopByUserIdAndRestaurantIdAndStatusInOrderByReservedDateDesc(
                     eq(userId), eq(restaurantId), any()))
                     .thenReturn(Optional.empty());
 

--- a/src/test/java/com/michelet/reservation/application/reservation/ReservationQueryServiceTest.java
+++ b/src/test/java/com/michelet/reservation/application/reservation/ReservationQueryServiceTest.java
@@ -54,7 +54,7 @@ class ReservationQueryServiceTest {
                 reservationId, userId, restaurantId, timeSlotId,
                 futureDate, GuestCount.of(2), ReservationStatus.CONFIRMED,
                 futureDate.minusDays(2), futureDate.minusDays(2),
-                LocalDateTime.of(futureDate, LocalTime.of(19, 30))
+                LocalDateTime.of(futureDate, LocalTime.of(19, 30)), null
         );
     }
 
@@ -205,7 +205,7 @@ class ReservationQueryServiceTest {
                     reservationId, userId, restaurantId, timeSlotId,
                     futureDate, GuestCount.of(2), ReservationStatus.CANCELLED,
                     futureDate.minusDays(2), futureDate.minusDays(2),
-                    LocalDateTime.of(futureDate, LocalTime.of(19, 30))
+                    LocalDateTime.of(futureDate, LocalTime.of(19, 30)), null
             );
             when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(cancelled));
 

--- a/src/test/java/com/michelet/reservation/application/reservation/ReservationQueryServiceTest.java
+++ b/src/test/java/com/michelet/reservation/application/reservation/ReservationQueryServiceTest.java
@@ -134,26 +134,31 @@ class ReservationQueryServiceTest {
     class CheckValidity {
 
         @Test
-        void CONFIRMED_또는_COMPLETED_예약이_있으면_exists_true() {
-            when(reservationRepository.existsByUserIdAndRestaurantIdAndStatusIn(
+        void CONFIRMED_또는_COMPLETED_예약이_있으면_예약_정보를_반환한다() {
+            Reservation reservation = confirmedReservation();
+            when(reservationRepository.findFirstByUserIdAndRestaurantIdAndStatusIn(
                     eq(userId), eq(restaurantId),
                     eq(List.of(ReservationStatus.CONFIRMED, ReservationStatus.COMPLETED))))
-                    .thenReturn(true);
+                    .thenReturn(Optional.of(reservation));
 
             ReservationValidityResult result = queryService.checkValidity(userId, restaurantId);
 
             assertThat(result.exists()).isTrue();
+            assertThat(result.reservationId()).isEqualTo(reservationId);
+            assertThat(result.reservationDate()).isEqualTo(futureDate);
         }
 
         @Test
-        void 해당_예약이_없으면_exists_false() {
-            when(reservationRepository.existsByUserIdAndRestaurantIdAndStatusIn(
+        void 해당_예약이_없으면_exists_false_이고_나머지_필드는_null이다() {
+            when(reservationRepository.findFirstByUserIdAndRestaurantIdAndStatusIn(
                     eq(userId), eq(restaurantId), any()))
-                    .thenReturn(false);
+                    .thenReturn(Optional.empty());
 
             ReservationValidityResult result = queryService.checkValidity(userId, restaurantId);
 
             assertThat(result.exists()).isFalse();
+            assertThat(result.reservationId()).isNull();
+            assertThat(result.reservationDate()).isNull();
         }
     }
 

--- a/src/test/java/com/michelet/reservation/domain/entity/ReservationTest.java
+++ b/src/test/java/com/michelet/reservation/domain/entity/ReservationTest.java
@@ -26,7 +26,7 @@ class ReservationTest {
         return Reservation.reconstitute(
                 UUID.randomUUID(), userId, restaurantId, timeSlotId,
                 futureDate, GuestCount.of(2), ReservationStatus.CONFIRMED,
-                futureDate.minusDays(2), futureDate.minusDays(2), noshowDeadline
+                futureDate.minusDays(2), futureDate.minusDays(2), noshowDeadline, null
         );
     }
 
@@ -36,7 +36,7 @@ class ReservationTest {
                 UUID.randomUUID(), userId, restaurantId, timeSlotId,
                 pastDate, GuestCount.of(2), ReservationStatus.CONFIRMED,
                 LocalDate.now().minusDays(1), LocalDate.now().minusDays(1),
-                LocalDateTime.of(pastDate, LocalTime.of(19, 30))
+                LocalDateTime.of(pastDate, LocalTime.of(19, 30)), null
         );
     }
 

--- a/src/test/java/com/michelet/reservation/presentation/reservation/ReservationInternalControllerTest.java
+++ b/src/test/java/com/michelet/reservation/presentation/reservation/ReservationInternalControllerTest.java
@@ -21,6 +21,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -45,16 +46,19 @@ class ReservationInternalControllerTest {
     class CheckValidity {
 
         @Test
-        void 예약이_있으면_exists_true를_반환한다() throws Exception {
+        void 예약이_있으면_exists_true와_예약_정보를_반환한다() throws Exception {
+            LocalDate reservationDate = LocalDate.of(2026, 6, 1);
             when(queryService.checkValidity(userId, restaurantId))
-                    .thenReturn(ReservationValidityResult.found());
+                    .thenReturn(new ReservationValidityResult(true, reservationId, reservationDate));
 
             mockMvc.perform(get("/internal/reservations/verify")
                             .param("userId", userId.toString())
                             .param("restaurantId", restaurantId.toString()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.data.exists").value(true));
+                    .andExpect(jsonPath("$.data.exists").value(true))
+                    .andExpect(jsonPath("$.data.reservationId").value(reservationId.toString()))
+                    .andExpect(jsonPath("$.data.reservationDate").value("2026-06-01"));
         }
 
         @Test

--- a/src/test/java/com/michelet/reservation/presentation/reservation/ReservationInternalControllerTest.java
+++ b/src/test/java/com/michelet/reservation/presentation/reservation/ReservationInternalControllerTest.java
@@ -76,7 +76,8 @@ class ReservationInternalControllerTest {
         @Test
         void 정상_체크인_시_200과_COMPLETED_상태를_반환한다() throws Exception {
             when(commandService.checkIn(any()))
-                    .thenReturn(new ReservationStatusResult(reservationId, ReservationStatus.COMPLETED));
+                    .thenReturn(new ReservationStatusResult(reservationId, ReservationStatus.COMPLETED,
+                            java.time.LocalDate.of(2026, 6, 1), java.time.LocalDateTime.now()));
 
             CheckInRequest req = new CheckInRequest(reservationId, restaurantId);
 


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- feign client timeslot waiting 맞춰 재수정
- delete 로직 다시 작성
- kafka 이벤트 발행자
- internal 함수 요청사항에 맞춰 수정

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #21   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [x] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.
<img width="1342" height="804" alt="image" src="https://github.com/user-attachments/assets/5c45fc76-52d9-4938-8aa6-76df6cccfd5f" />

<img width="1858" height="766" alt="image" src="https://github.com/user-attachments/assets/d5db3098-0c62-4a64-8ce6-cabb170e44d6" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 예약 삭제(DELETE) API 추가 및 삭제 성공 응답 코드 추가
  * 예약 생성 시 이벤트 발행(Kafka) 구현 및 Kafka 스텁 제공
  * 요청 처리 시 사용자 ID를 MDC에 기록하는 필터 추가

* **개선사항**
  * 예약 상태에 visitDate·checkedInAt 추가 표출 및 체크인 시각 기록
  * 대기 토큰 검증·완료 흐름 보완 및 내부 검증 응답 확장
  * 시간대 재고 증감 호출 경로·동작 및 예약 중복 판단 보정

* **테스트**
  * 생성·삭제·체크인·대기 관련 테스트 보강 및 응답 검증 확대
<!-- end of auto-generated comment: release notes by coderabbit.ai -->