### PR TITLE
[Refactor] state pattern 적용 및 상태 변경 책임 도메인에 이동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 
@@ -25,7 +25,7 @@ ext {
 dependencies {
     implementation 'com.github.Miche-Let:common:dev-SNAPSHOT'
     implementation 'com.github.Miche-Let:common-auth-webmvc:0.1.5'
-    implementation 'com.github.Miche-Let:common-auth-feign:0.1.1'
+    implementation 'com.github.Miche-Let:common-auth-feign:0.1.2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -35,7 +35,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
-    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+//    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.kafka:spring-kafka'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/http/reservation.http
+++ b/http/reservation.http
@@ -14,7 +14,7 @@
 #   CANCELLED_UNPAID — feign 실패 감지 시 자동 취소 / 미래 outbox 패턴 (WAITING → 슬롯 미점유)
 #   COMPLETED      — 체크인 완료
 #   NO_SHOW        — noshowDeadline 초과 미체크인
-#
+#아
 # 가정하는 전체 플로우
 #   1. 예약 등록            → WAITING 저장 → feign 점유 성공 → CONFIRMED 전환, reservation_id 저장
 #   2. 목록 조회 (전체)     → 생성된 예약이 목록에 포함됨을 확인

--- a/http/reservation.http
+++ b/http/reservation.http
@@ -14,7 +14,6 @@
 #   CANCELLED_UNPAID — feign 실패 감지 시 자동 취소 / 미래 outbox 패턴 (WAITING → 슬롯 미점유)
 #   COMPLETED      — 체크인 완료
 #   NO_SHOW        — noshowDeadline 초과 미체크인
-#아
 # 가정하는 전체 플로우
 #   1. 예약 등록            → WAITING 저장 → feign 점유 성공 → CONFIRMED 전환, reservation_id 저장
 #   2. 목록 조회 (전체)     → 생성된 예약이 목록에 포함됨을 확인
@@ -55,15 +54,15 @@ Content-Type: application/json
 }
 
 > {%
-  client.test("201 Created", function() {
-    client.assert(response.status === 201, "Expected 201, got " + response.status);
-  });
-  client.test("status CONFIRMED (WAITING→CONFIRMED 전환 완료)", function() {
-    client.assert(response.body.data.status === "CONFIRMED", "Expected CONFIRMED, got " + response.body.data.status);
-  });
-  if (response.status === 201) {
-    client.global.set("reservation_id", response.body.data.reservationId);
-  }
+    client.test("201 Created", function () {
+        client.assert(response.status === 201, "Expected 201, got " + response.status);
+    });
+    client.test("status CONFIRMED (WAITING→CONFIRMED 전환 완료)", function () {
+        client.assert(response.body.data.status === "CONFIRMED", "Expected CONFIRMED, got " + response.body.data.status);
+    });
+    if (response.status === 201) {
+        client.global.set("reservation_id", response.body.data.reservationId);
+    }
 %}
 
 ###
@@ -77,9 +76,9 @@ X-User-Id: {{user_id}}
 X-User-Role: USER
 
 > {%
-  client.test("200 OK", function() {
-    client.assert(response.status === 200, "Expected 200, got " + response.status);
-  });
+    client.test("200 OK", function () {
+        client.assert(response.status === 200, "Expected 200, got " + response.status);
+    });
 %}
 
 ###
@@ -94,9 +93,9 @@ X-User-Id: {{user_id}}
 X-User-Role: USER
 
 > {%
-  client.test("200 OK", function() {
-    client.assert(response.status === 200, "Expected 200, got " + response.status);
-  });
+    client.test("200 OK", function () {
+        client.assert(response.status === 200, "Expected 200, got " + response.status);
+    });
 %}
 
 ###
@@ -110,12 +109,12 @@ X-User-Id: {{user_id}}
 X-User-Role: USER
 
 > {%
-  client.test("200 OK", function() {
-    client.assert(response.status === 200, "Expected 200, got " + response.status);
-  });
-  client.test("status CONFIRMED", function() {
-    client.assert(response.body.data.status === "CONFIRMED", "Expected CONFIRMED, got " + response.body.data.status);
-  });
+    client.test("200 OK", function () {
+        client.assert(response.status === 200, "Expected 200, got " + response.status);
+    });
+    client.test("status CONFIRMED", function () {
+        client.assert(response.body.data.status === "CONFIRMED", "Expected CONFIRMED, got " + response.body.data.status);
+    });
 %}
 
 ###
@@ -134,9 +133,9 @@ Content-Type: application/json
 }
 
 > {%
-  client.test("200 OK", function() {
-    client.assert(response.status === 200, "Expected 200, got " + response.status);
-  });
+    client.test("200 OK", function () {
+        client.assert(response.status === 200, "Expected 200, got " + response.status);
+    });
 %}
 
 ###
@@ -156,9 +155,9 @@ Content-Type: application/json
 }
 
 > {%
-  client.test("200 OK", function() {
-    client.assert(response.status === 200, "Expected 200, got " + response.status);
-  });
+    client.test("200 OK", function () {
+        client.assert(response.status === 200, "Expected 200, got " + response.status);
+    });
 %}
 
 ###
@@ -168,35 +167,42 @@ Content-Type: application/json
 # [데이터] userId + restaurantId 조합으로 유효 상태 예약 조회
 # [기대]   200 OK, exists=true, reservationId 및 reservationDate 포함
 < {%
-  (function() {
-    function b64url(str) {
-      return btoa(unescape(encodeURIComponent(str))).replace(/=/g,'').replace(/\+/g,'-').replace(/\//g,'_');
-    }
-    const header = b64url(JSON.stringify({alg:"HS256",typ:"JWT"}));
-    const now = Math.floor(Date.now() / 1000);
-    const payload = b64url(JSON.stringify({iss:"http-test-client",sub:"internal-call",aud:["reservation-service"],iat:now,exp:now+60}));
-    const si = header + "." + payload;
-    const sig = CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA256(si, "michelet-internal-auth-secret-key-a8K2mQ9xLp4Vt7Rz1Nc"))
-      .replace(/=/g,'').replace(/\+/g,'-').replace(/\//g,'_');
-    client.global.set("internal_token", si + "." + sig);
-  })();
+    (function () {
+        function b64url(str) {
+            return btoa(unescape(encodeURIComponent(str))).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+        }
+
+        const header = b64url(JSON.stringify({alg: "HS256", typ: "JWT"}));
+        const now = Math.floor(Date.now() / 1000);
+        const payload = b64url(JSON.stringify({
+            iss: "http-test-client",
+            sub: "internal-call",
+            aud: ["reservation-service"],
+            iat: now,
+            exp: now + 60
+        }));
+        const si = header + "." + payload;
+        const sig = CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA256(si, "michelet-internal-auth-secret-key-a8K2mQ9xLp4Vt7Rz1Nc"))
+            .replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+        client.global.set("internal_token", si + "." + sig);
+    })();
 %}
 GET {{base_url}}/internal/reservations/verify?userId={{user_id}}&restaurantId={{restaurant_id}}
 X-Internal-Token: {{internal_token}}
 
 > {%
-  client.test("200 OK", function() {
-    client.assert(response.status === 200, "Expected 200, got " + response.status);
-  });
-  client.test("exists true", function() {
-    client.assert(response.body.data.exists === true, "Expected exists=true");
-  });
-  client.test("reservationId 존재", function() {
-    client.assert(response.body.data.reservationId != null, "Expected reservationId");
-  });
-  client.test("reservationDate 존재", function() {
-    client.assert(response.body.data.reservationDate != null, "Expected reservationDate");
-  });
+    client.test("200 OK", function () {
+        client.assert(response.status === 200, "Expected 200, got " + response.status);
+    });
+    client.test("exists true", function () {
+        client.assert(response.body.data.exists === true, "Expected exists=true");
+    });
+    client.test("reservationId 존재", function () {
+        client.assert(response.body.data.reservationId != null, "Expected reservationId");
+    });
+    client.test("reservationDate 존재", function () {
+        client.assert(response.body.data.reservationDate != null, "Expected reservationDate");
+    });
 %}
 
 ###
@@ -206,29 +212,36 @@ X-Internal-Token: {{internal_token}}
 # [데이터] 1번에서 생성한 예약이 CONFIRMED 상태이므로 exists=true
 # [기대]   200 OK, exists=true
 < {%
-  (function() {
-    function b64url(str) {
-      return btoa(unescape(encodeURIComponent(str))).replace(/=/g,'').replace(/\+/g,'-').replace(/\//g,'_');
-    }
-    const header = b64url(JSON.stringify({alg:"HS256",typ:"JWT"}));
-    const now = Math.floor(Date.now() / 1000);
-    const payload = b64url(JSON.stringify({iss:"http-test-client",sub:"internal-call",aud:["reservation-service"],iat:now,exp:now+60}));
-    const si = header + "." + payload;
-    const sig = CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA256(si, "michelet-internal-auth-secret-key-a8K2mQ9xLp4Vt7Rz1Nc"))
-      .replace(/=/g,'').replace(/\+/g,'-').replace(/\//g,'_');
-    client.global.set("internal_token", si + "." + sig);
-  })();
+    (function () {
+        function b64url(str) {
+            return btoa(unescape(encodeURIComponent(str))).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+        }
+
+        const header = b64url(JSON.stringify({alg: "HS256", typ: "JWT"}));
+        const now = Math.floor(Date.now() / 1000);
+        const payload = b64url(JSON.stringify({
+            iss: "http-test-client",
+            sub: "internal-call",
+            aud: ["reservation-service"],
+            iat: now,
+            exp: now + 60
+        }));
+        const si = header + "." + payload;
+        const sig = CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA256(si, "michelet-internal-auth-secret-key-a8K2mQ9xLp4Vt7Rz1Nc"))
+            .replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+        client.global.set("internal_token", si + "." + sig);
+    })();
 %}
 GET {{base_url}}/internal/reservations/active?userId={{user_id}}
 X-Internal-Token: {{internal_token}}
 
 > {%
-  client.test("200 OK", function() {
-    client.assert(response.status === 200, "Expected 200, got " + response.status);
-  });
-  client.test("exists true (체크인 전 CONFIRMED)", function() {
-    client.assert(response.body.data.exists === true, "Expected exists=true");
-  });
+    client.test("200 OK", function () {
+        client.assert(response.status === 200, "Expected 200, got " + response.status);
+    });
+    client.test("exists true (체크인 전 CONFIRMED)", function () {
+        client.assert(response.body.data.exists === true, "Expected exists=true");
+    });
 %}
 
 ###
@@ -238,18 +251,25 @@ X-Internal-Token: {{internal_token}}
 # [데이터] reservation_id + restaurantId (restaurantId 불일치 시 404)
 # [기대]   200 OK, status=COMPLETED, checkedInAt 포함
 < {%
-  (function() {
-    function b64url(str) {
-      return btoa(unescape(encodeURIComponent(str))).replace(/=/g,'').replace(/\+/g,'-').replace(/\//g,'_');
-    }
-    const header = b64url(JSON.stringify({alg:"HS256",typ:"JWT"}));
-    const now = Math.floor(Date.now() / 1000);
-    const payload = b64url(JSON.stringify({iss:"http-test-client",sub:"internal-call",aud:["reservation-service"],iat:now,exp:now+60}));
-    const si = header + "." + payload;
-    const sig = CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA256(si, "michelet-internal-auth-secret-key-a8K2mQ9xLp4Vt7Rz1Nc"))
-      .replace(/=/g,'').replace(/\+/g,'-').replace(/\//g,'_');
-    client.global.set("internal_token", si + "." + sig);
-  })();
+    (function () {
+        function b64url(str) {
+            return btoa(unescape(encodeURIComponent(str))).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+        }
+
+        const header = b64url(JSON.stringify({alg: "HS256", typ: "JWT"}));
+        const now = Math.floor(Date.now() / 1000);
+        const payload = b64url(JSON.stringify({
+            iss: "http-test-client",
+            sub: "internal-call",
+            aud: ["reservation-service"],
+            iat: now,
+            exp: now + 60
+        }));
+        const si = header + "." + payload;
+        const sig = CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA256(si, "michelet-internal-auth-secret-key-a8K2mQ9xLp4Vt7Rz1Nc"))
+            .replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+        client.global.set("internal_token", si + "." + sig);
+    })();
 %}
 PATCH {{base_url}}/internal/reservations/check-in
 X-Internal-Token: {{internal_token}}
@@ -261,15 +281,15 @@ Content-Type: application/json
 }
 
 > {%
-  client.test("200 OK", function() {
-    client.assert(response.status === 200, "Expected 200, got " + response.status);
-  });
-  client.test("status COMPLETED", function() {
-    client.assert(response.body.data.status === "COMPLETED", "Expected COMPLETED");
-  });
-  client.test("checkedInAt 존재", function() {
-    client.assert(response.body.data.checkedInAt != null, "Expected checkedInAt");
-  });
+    client.test("200 OK", function () {
+        client.assert(response.status === 200, "Expected 200, got " + response.status);
+    });
+    client.test("status COMPLETED", function () {
+        client.assert(response.body.data.status === "COMPLETED", "Expected COMPLETED");
+    });
+    client.test("checkedInAt 존재", function () {
+        client.assert(response.body.data.checkedInAt != null, "Expected checkedInAt");
+    });
 %}
 
 ###
@@ -279,29 +299,37 @@ Content-Type: application/json
 # [데이터] 6번 체크인 완료 후 COMPLETED 상태가 된 예약으로 조회
 # [기대]   200 OK, exists=false (checkExists는 CONFIRMED 상태만 검사 — 체크인 후 COMPLETED이므로 false)
 < {%
-  (function() {
-    function b64url(str) {
-      return btoa(unescape(encodeURIComponent(str))).replace(/=/g,'').replace(/\+/g,'-').replace(/\//g,'_');
-    }
-    const header = b64url(JSON.stringify({alg:"HS256",typ:"JWT"}));
-    const now = Math.floor(Date.now() / 1000);
-    const payload = b64url(JSON.stringify({iss:"http-test-client",sub:"internal-call",aud:["reservation-service"],iat:now,exp:now+60}));
-    const si = header + "." + payload;
-    const sig = CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA256(si, "michelet-internal-auth-secret-key-a8K2mQ9xLp4Vt7Rz1Nc"))
-      .replace(/=/g,'').replace(/\+/g,'-').replace(/\//g,'_');
-    client.global.set("internal_token", si + "." + sig);
-  })();
+    (function () {
+        function b64url(str) {
+            return btoa(unescape(encodeURIComponent(str))).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+        }
+
+        const header = b64url(JSON.stringify({alg: "HS256", typ: "JWT"}));
+        const now = Math.floor(Date.now() / 1000);
+        const payload = b64url(JSON.stringify({
+            iss: "http-test-client",
+            sub: "internal-call",
+            aud: ["reservation-service"],
+            iat: now,
+            exp: now + 60
+        }));
+        const si = header + "." + payload;
+        const sig = CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA256(si, "michelet-internal-auth-secret-key-a8K2mQ9xLp4Vt7Rz1Nc"))
+            .replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+        client.global.set("internal_token", si + "." + sig);
+    })();
 %}
-GET {{base_url}}/internal/reservations/exists?reservationId={{reservation_id}}&userId={{user_id}}&restaurantId={{restaurant_id}}
+GET {{base_url}}/internal/reservations/exists?reservationId={{reservation_id}}&userId={{user_id}}&
+    restaurantId={{restaurant_id}}
 X-Internal-Token: {{internal_token}}
 
 > {%
-  client.test("200 OK", function() {
-    client.assert(response.status === 200, "Expected 200, got " + response.status);
-  });
-  client.test("exists false (COMPLETED 상태는 CONFIRMED 아님)", function() {
-    client.assert(response.body.data.exists === false, "Expected exists=false");
-  });
+    client.test("200 OK", function () {
+        client.assert(response.status === 200, "Expected 200, got " + response.status);
+    });
+    client.test("exists false (COMPLETED 상태는 CONFIRMED 아님)", function () {
+        client.assert(response.body.data.exists === false, "Expected exists=false");
+    });
 %}
 
 ###
@@ -317,12 +345,12 @@ X-User-Id: {{user_id}}
 X-User-Role: USER
 
 > {%
-  client.test("200 OK", function() {
-    client.assert(response.status === 200, "Expected 200, got " + response.status);
-  });
-  client.test("status COMPLETED (체크인 완료)", function() {
-    client.assert(response.body.data.status === "COMPLETED", "Expected status=COMPLETED");
-  });
+    client.test("200 OK", function () {
+        client.assert(response.status === 200, "Expected 200, got " + response.status);
+    });
+    client.test("status COMPLETED (체크인 완료)", function () {
+        client.assert(response.body.data.status === "COMPLETED", "Expected status=COMPLETED");
+    });
 %}
 
 ###
@@ -337,9 +365,9 @@ X-User-Id: {{user_id}}
 X-User-Role: USER
 
 > {%
-  client.test("200 OK", function() {
-    client.assert(response.status === 200, "Expected 200, got " + response.status);
-  });
+    client.test("200 OK", function () {
+        client.assert(response.status === 200, "Expected 200, got " + response.status);
+    });
 %}
 
 ###

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
@@ -139,7 +139,7 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     public void delete(DeleteReservationCommand command) {
         Reservation reservation = findAndVerifyOwnership(command.reservationId(), command.userId(), command.userRole());
         reservationRepository.delete(reservation.getId(), command.userId());
-        if (reservation.getStatus() == ReservationStatus.CONFIRMED) {
+        if (reservation.requiresSlotReturn()) {
             timeSlotPort.incrementStock(reservation.getTimeSlotId(), reservation.getGuestCount().value());
         }
     }

--- a/src/main/java/com/michelet/reservation/domain/entity/Reservation.java
+++ b/src/main/java/com/michelet/reservation/domain/entity/Reservation.java
@@ -2,6 +2,7 @@ package com.michelet.reservation.domain.entity;
 
 import com.michelet.common.exception.BusinessException;
 import com.michelet.reservation.domain.enums.ReservationStatus;
+import com.michelet.reservation.domain.enums.ReservationTransition;
 import com.michelet.reservation.domain.exception.ReservationErrorCode;
 import com.michelet.reservation.domain.vo.GuestCount;
 import lombok.AccessLevel;
@@ -87,12 +88,12 @@ public class Reservation {
   }
 
   public void confirm() {
-    validateTransition(ReservationStatus.WAITING);
+    validateTransition(ReservationStatus.CONFIRMED);
     this.status = ReservationStatus.CONFIRMED;
   }
 
   public void cancel() {
-    validateTransition(ReservationStatus.CONFIRMED);
+    validateTransition(ReservationStatus.CANCELLED_PAID);
     if (LocalDate.now().isAfter(cancelDeadline)) {
       throw new BusinessException(ReservationErrorCode.CANCEL_DEADLINE_EXCEEDED);
     }
@@ -100,18 +101,18 @@ public class Reservation {
   }
 
   public void cancelUnpaid() {
-    validateTransition(ReservationStatus.WAITING);
+    validateTransition(ReservationStatus.CANCELLED_UNPAID);
     this.status = ReservationStatus.CANCELLED_UNPAID;
   }
 
   public void complete() {
-    validateTransition(ReservationStatus.CONFIRMED);
+    validateTransition(ReservationStatus.COMPLETED);
     this.status = ReservationStatus.COMPLETED;
     this.checkedInAt = LocalDateTime.now();
   }
 
   public void markNoShow() {
-    validateTransition(ReservationStatus.CONFIRMED);
+    validateTransition(ReservationStatus.NO_SHOW);
     this.status = ReservationStatus.NO_SHOW;
   }
 
@@ -121,7 +122,7 @@ public class Reservation {
       GuestCount newGuestCount,
       LocalDateTime newNoshowDeadline
   ) {
-    validateTransition(ReservationStatus.CONFIRMED);
+    requireStatus(ReservationStatus.CONFIRMED);
     if (LocalDate.now().isAfter(modifyDeadline)) {
       throw new BusinessException(ReservationErrorCode.MODIFY_DEADLINE_EXCEEDED);
     }
@@ -133,7 +134,13 @@ public class Reservation {
     this.noshowDeadline = newNoshowDeadline;
   }
 
-  private void validateTransition(ReservationStatus required) {
+  private void validateTransition(ReservationStatus to) {
+    if (!ReservationTransition.isAllowed(this.status, to)) {
+      throw new BusinessException(ReservationErrorCode.INVALID_STATUS_TRANSITION);
+    }
+  }
+
+  private void requireStatus(ReservationStatus required) {
     if (this.status != required) {
       throw new BusinessException(ReservationErrorCode.INVALID_STATUS_TRANSITION);
     }

--- a/src/main/java/com/michelet/reservation/domain/entity/Reservation.java
+++ b/src/main/java/com/michelet/reservation/domain/entity/Reservation.java
@@ -2,8 +2,9 @@ package com.michelet.reservation.domain.entity;
 
 import com.michelet.common.exception.BusinessException;
 import com.michelet.reservation.domain.enums.ReservationStatus;
-import com.michelet.reservation.domain.enums.ReservationTransition;
 import com.michelet.reservation.domain.exception.ReservationErrorCode;
+import com.michelet.reservation.domain.state.ReservationState;
+import com.michelet.reservation.domain.state.ReservationStateFactory;
 import com.michelet.reservation.domain.vo.GuestCount;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -25,6 +26,7 @@ public class Reservation {
   private LocalDate reservedDate;
   private GuestCount guestCount;
   private ReservationStatus status;
+  private transient ReservationState state; // JPA 영속화 대상 아님
 
   private LocalDate cancelDeadline;
 
@@ -52,6 +54,7 @@ public class Reservation {
     r.reservedDate   = reservedDate;
     r.guestCount     = guestCount;
     r.status         = ReservationStatus.WAITING;
+    r.state          = ReservationStateFactory.from(ReservationStatus.WAITING);
     r.cancelDeadline = reservedDate.minusDays(2);
     r.modifyDeadline = reservedDate.minusDays(2);
     r.noshowDeadline = noshowDeadline; // 타임슬롯 데이터를 가져와서 설정함
@@ -71,7 +74,7 @@ public class Reservation {
       LocalDateTime noshowDeadline,
       LocalDateTime checkedInAt
   ) {
-    validateReconstituteInput(id,userId, restaurantId, timeSlotId, reservedDate, guestCount);
+    validateReconstituteInput(id, userId, restaurantId, timeSlotId, reservedDate, guestCount);
     Reservation r = new Reservation();
     r.id             = id;
     r.userId         = userId;
@@ -80,6 +83,7 @@ public class Reservation {
     r.reservedDate   = reservedDate;
     r.guestCount     = guestCount;
     r.status         = status;
+    r.state          = ReservationStateFactory.from(status);
     r.cancelDeadline = cancelDeadline;
     r.modifyDeadline = modifyDeadline;
     r.noshowDeadline = noshowDeadline;
@@ -88,50 +92,47 @@ public class Reservation {
   }
 
   public void confirm() {
-    validateTransition(ReservationStatus.CONFIRMED);
-    this.status = ReservationStatus.CONFIRMED;
+    this.status = state.confirm();
+    this.state  = ReservationStateFactory.from(this.status);
   }
 
   public void cancel() {
-    validateTransition(ReservationStatus.CANCELLED_PAID);
-    if (LocalDate.now().isAfter(cancelDeadline)) {
-      throw new BusinessException(ReservationErrorCode.CANCEL_DEADLINE_EXCEEDED);
-    }
-    this.status = ReservationStatus.CANCELLED_PAID;
+    this.status = state.cancel(this.cancelDeadline);
+    this.state  = ReservationStateFactory.from(this.status);
   }
 
   public void cancelUnpaid() {
-    validateTransition(ReservationStatus.CANCELLED_UNPAID);
-    this.status = ReservationStatus.CANCELLED_UNPAID;
+    this.status = state.cancelUnpaid();
+    this.state  = ReservationStateFactory.from(this.status);
   }
 
   public void complete() {
-    validateTransition(ReservationStatus.COMPLETED);
-    this.status = ReservationStatus.COMPLETED;
+    this.status      = state.complete();
+    this.state       = ReservationStateFactory.from(this.status);
     this.checkedInAt = LocalDateTime.now();
   }
 
   public void markNoShow() {
-    validateTransition(ReservationStatus.NO_SHOW);
-    this.status = ReservationStatus.NO_SHOW;
+    this.status = state.markNoShow();
+    this.state  = ReservationStateFactory.from(this.status);
   }
 
   public boolean requiresSlotReturn() {
-    return this.status == ReservationStatus.CONFIRMED;
+    return state.requiresSlotReturn();
   }
 
   public boolean isCancellable() {
-    return this.status == ReservationStatus.CONFIRMED
+    return state.status() == ReservationStatus.CONFIRMED
         && !LocalDate.now().isAfter(cancelDeadline);
   }
 
   public boolean isModifiable() {
-    return this.status == ReservationStatus.CONFIRMED
+    return state.status() == ReservationStatus.CONFIRMED
         && !LocalDate.now().isAfter(modifyDeadline);
   }
 
   public boolean requiresRefund() {
-    return this.status == ReservationStatus.CANCELLED_PAID;
+    return state.requiresRefund();
   }
 
   public void modify(
@@ -140,7 +141,9 @@ public class Reservation {
       GuestCount newGuestCount,
       LocalDateTime newNoshowDeadline
   ) {
-    requireStatus(ReservationStatus.CONFIRMED);
+    if (state.status() != ReservationStatus.CONFIRMED) {
+      throw new BusinessException(ReservationErrorCode.INVALID_STATUS_TRANSITION);
+    }
     if (LocalDate.now().isAfter(modifyDeadline)) {
       throw new BusinessException(ReservationErrorCode.MODIFY_DEADLINE_EXCEEDED);
     }
@@ -150,18 +153,6 @@ public class Reservation {
     this.cancelDeadline = newReservedDate.minusDays(2);
     this.modifyDeadline = newReservedDate.minusDays(2);
     this.noshowDeadline = newNoshowDeadline;
-  }
-
-  private void validateTransition(ReservationStatus to) {
-    if (!ReservationTransition.isAllowed(this.status, to)) {
-      throw new BusinessException(ReservationErrorCode.INVALID_STATUS_TRANSITION);
-    }
-  }
-
-  private void requireStatus(ReservationStatus required) {
-    if (this.status != required) {
-      throw new BusinessException(ReservationErrorCode.INVALID_STATUS_TRANSITION);
-    }
   }
 
   private static void validateCreateInput(

--- a/src/main/java/com/michelet/reservation/domain/entity/Reservation.java
+++ b/src/main/java/com/michelet/reservation/domain/entity/Reservation.java
@@ -116,6 +116,24 @@ public class Reservation {
     this.status = ReservationStatus.NO_SHOW;
   }
 
+  public boolean requiresSlotReturn() {
+    return this.status == ReservationStatus.CONFIRMED;
+  }
+
+  public boolean isCancellable() {
+    return this.status == ReservationStatus.CONFIRMED
+        && !LocalDate.now().isAfter(cancelDeadline);
+  }
+
+  public boolean isModifiable() {
+    return this.status == ReservationStatus.CONFIRMED
+        && !LocalDate.now().isAfter(modifyDeadline);
+  }
+
+  public boolean requiresRefund() {
+    return this.status == ReservationStatus.CANCELLED_PAID;
+  }
+
   public void modify(
       UUID newTimeSlotId,
       LocalDate newReservedDate,

--- a/src/main/java/com/michelet/reservation/domain/entity/Reservation.java
+++ b/src/main/java/com/michelet/reservation/domain/entity/Reservation.java
@@ -6,181 +6,206 @@ import com.michelet.reservation.domain.exception.ReservationErrorCode;
 import com.michelet.reservation.domain.state.ReservationState;
 import com.michelet.reservation.domain.state.ReservationStateFactory;
 import com.michelet.reservation.domain.vo.GuestCount;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Reservation {
 
-  private UUID id;
-  private boolean isNew;
-  private UUID userId;
-  private UUID restaurantId;
-  private UUID timeSlotId;
-  private LocalDate reservedDate;
-  private GuestCount guestCount;
-  private ReservationStatus status;
-  private transient ReservationState state; // JPA 영속화 대상 아님
+    private UUID id;
+    private boolean isNew;
+    private UUID userId;
+    private UUID restaurantId;
+    private UUID timeSlotId;
+    private LocalDate reservedDate;
+    private GuestCount guestCount;
+    private ReservationStatus status;
+    private transient ReservationState state; // JPA 영속화 대상 아님
 
-  private LocalDate cancelDeadline;
+    private LocalDate cancelDeadline;
 
-  private LocalDate modifyDeadline;
+    private LocalDate modifyDeadline;
 
-  private LocalDateTime noshowDeadline;
+    private LocalDateTime noshowDeadline;
 
-  private LocalDateTime checkedInAt;
+    private LocalDateTime checkedInAt;
 
-  public static Reservation create(
-      UUID userId,
-      UUID restaurantId,
-      UUID timeSlotId,
-      LocalDate reservedDate,
-      GuestCount guestCount,
-      LocalDateTime noshowDeadline
-  ) {
-    validateCreateInput(userId, restaurantId, timeSlotId, reservedDate, guestCount);
-    Reservation r = new Reservation();
-    r.id             = UUID.randomUUID();
-    r.isNew          = true;
-    r.userId         = userId;
-    r.restaurantId   = restaurantId;
-    r.timeSlotId     = timeSlotId;
-    r.reservedDate   = reservedDate;
-    r.guestCount     = guestCount;
-    r.status         = ReservationStatus.WAITING;
-    r.state          = ReservationStateFactory.from(ReservationStatus.WAITING);
-    r.cancelDeadline = reservedDate.minusDays(2);
-    r.modifyDeadline = reservedDate.minusDays(2);
-    r.noshowDeadline = noshowDeadline; // 타임슬롯 데이터를 가져와서 설정함
-    return r;
-  }
-
-  public static Reservation reconstitute(
-      UUID id,
-      UUID userId,
-      UUID restaurantId,
-      UUID timeSlotId,
-      LocalDate reservedDate,
-      GuestCount guestCount,
-      ReservationStatus status,
-      LocalDate cancelDeadline,
-      LocalDate modifyDeadline,
-      LocalDateTime noshowDeadline,
-      LocalDateTime checkedInAt
-  ) {
-    validateReconstituteInput(id, userId, restaurantId, timeSlotId, reservedDate, guestCount);
-    Reservation r = new Reservation();
-    r.id             = id;
-    r.userId         = userId;
-    r.restaurantId   = restaurantId;
-    r.timeSlotId     = timeSlotId;
-    r.reservedDate   = reservedDate;
-    r.guestCount     = guestCount;
-    r.status         = status;
-    r.state          = ReservationStateFactory.from(status);
-    r.cancelDeadline = cancelDeadline;
-    r.modifyDeadline = modifyDeadline;
-    r.noshowDeadline = noshowDeadline;
-    r.checkedInAt    = checkedInAt;
-    return r;
-  }
-
-  public void confirm() {
-    this.status = state.confirm();
-    this.state  = ReservationStateFactory.from(this.status);
-  }
-
-  public void cancel() {
-    this.status = state.cancel(this.cancelDeadline);
-    this.state  = ReservationStateFactory.from(this.status);
-  }
-
-  public void cancelUnpaid() {
-    this.status = state.cancelUnpaid();
-    this.state  = ReservationStateFactory.from(this.status);
-  }
-
-  public void complete() {
-    this.status      = state.complete();
-    this.state       = ReservationStateFactory.from(this.status);
-    this.checkedInAt = LocalDateTime.now();
-  }
-
-  public void markNoShow() {
-    this.status = state.markNoShow();
-    this.state  = ReservationStateFactory.from(this.status);
-  }
-
-  public boolean requiresSlotReturn() {
-    return state.requiresSlotReturn();
-  }
-
-  public boolean isCancellable() {
-    return state.status() == ReservationStatus.CONFIRMED
-        && !LocalDate.now().isAfter(cancelDeadline);
-  }
-
-  public boolean isModifiable() {
-    return state.status() == ReservationStatus.CONFIRMED
-        && !LocalDate.now().isAfter(modifyDeadline);
-  }
-
-  public boolean requiresRefund() {
-    return state.requiresRefund();
-  }
-
-  public void modify(
-      UUID newTimeSlotId,
-      LocalDate newReservedDate,
-      GuestCount newGuestCount,
-      LocalDateTime newNoshowDeadline
-  ) {
-    if (state.status() != ReservationStatus.CONFIRMED) {
-      throw new BusinessException(ReservationErrorCode.INVALID_STATUS_TRANSITION);
+    public static Reservation create(
+            UUID userId,
+            UUID restaurantId,
+            UUID timeSlotId,
+            LocalDate reservedDate,
+            GuestCount guestCount,
+            LocalDateTime noshowDeadline
+    ) {
+        validateCreateInput(userId, restaurantId, timeSlotId, reservedDate, guestCount);
+        Reservation r = new Reservation();
+        r.id = UUID.randomUUID();
+        r.isNew = true;
+        r.userId = userId;
+        r.restaurantId = restaurantId;
+        r.timeSlotId = timeSlotId;
+        r.reservedDate = reservedDate;
+        r.guestCount = guestCount;
+        r.status = ReservationStatus.WAITING;
+        r.state = ReservationStateFactory.from(ReservationStatus.WAITING);
+        r.cancelDeadline = reservedDate.minusDays(2);
+        r.modifyDeadline = reservedDate.minusDays(2);
+        r.noshowDeadline = noshowDeadline; // 타임슬롯 데이터를 가져와서 설정함
+        return r;
     }
-    if (LocalDate.now().isAfter(modifyDeadline)) {
-      throw new BusinessException(ReservationErrorCode.MODIFY_DEADLINE_EXCEEDED);
+
+    public static Reservation reconstitute(
+            UUID id,
+            UUID userId,
+            UUID restaurantId,
+            UUID timeSlotId,
+            LocalDate reservedDate,
+            GuestCount guestCount,
+            ReservationStatus status,
+            LocalDate cancelDeadline,
+            LocalDate modifyDeadline,
+            LocalDateTime noshowDeadline,
+            LocalDateTime checkedInAt
+    ) {
+        validateReconstituteInput(id, userId, restaurantId, timeSlotId, reservedDate, guestCount, status);
+        Reservation r = new Reservation();
+        r.id = id;
+        r.userId = userId;
+        r.restaurantId = restaurantId;
+        r.timeSlotId = timeSlotId;
+        r.reservedDate = reservedDate;
+        r.guestCount = guestCount;
+        r.status = status;
+        r.state = ReservationStateFactory.from(status);
+        r.cancelDeadline = cancelDeadline;
+        r.modifyDeadline = modifyDeadline;
+        r.noshowDeadline = noshowDeadline;
+        r.checkedInAt = checkedInAt;
+        return r;
     }
-    this.timeSlotId     = newTimeSlotId;
-    this.reservedDate   = newReservedDate;
-    this.guestCount     = newGuestCount;
-    this.cancelDeadline = newReservedDate.minusDays(2);
-    this.modifyDeadline = newReservedDate.minusDays(2);
-    this.noshowDeadline = newNoshowDeadline;
-  }
 
-  private static void validateCreateInput(
-      UUID userId,
-      UUID restaurantId,
-      UUID timeSlotId,
-      LocalDate reservedDate,
-      GuestCount guestCount) {
-    if (userId == null)         throw new BusinessException(ReservationErrorCode.INVALID_USER_ID);
-    if (restaurantId == null)   throw new BusinessException(ReservationErrorCode.INVALID_RESTAURANT_ID);
-    if (timeSlotId == null)     throw new BusinessException(ReservationErrorCode.INVALID_TIME_SLOT_ID);
-    if (reservedDate == null)   throw new BusinessException(ReservationErrorCode.INVALID_RESERVED_DATE);
-    if (guestCount == null)     throw new BusinessException(ReservationErrorCode.INVALID_GUEST_COUNT_NULL);
-  }
+    public void confirm() {
+        this.status = state.confirm();
+        this.state = ReservationStateFactory.from(this.status);
+    }
 
-  private static void validateReconstituteInput(
-      UUID id,
-      UUID userId,
-      UUID restaurantId,
-      UUID timeSlotId,
-      LocalDate reservedDate,
-      GuestCount guestCount
-  ) {
-    if (id == null)            throw new BusinessException(ReservationErrorCode.RESERVATION_NOT_FOUND);
-    if (userId == null)        throw new BusinessException(ReservationErrorCode.INVALID_USER_ID);
-    if (restaurantId == null)  throw new BusinessException(ReservationErrorCode.INVALID_RESTAURANT_ID);
-    if (timeSlotId == null)    throw new BusinessException(ReservationErrorCode.INVALID_TIME_SLOT_ID);
-    if (reservedDate == null)  throw new BusinessException(ReservationErrorCode.INVALID_RESERVED_DATE);
-    if (guestCount == null)    throw new BusinessException(ReservationErrorCode.INVALID_GUEST_COUNT_NULL);
-  }
+    public void cancel() {
+        this.status = state.cancel(this.cancelDeadline);
+        this.state = ReservationStateFactory.from(this.status);
+    }
+
+    public void cancelUnpaid() {
+        this.status = state.cancelUnpaid();
+        this.state = ReservationStateFactory.from(this.status);
+    }
+
+    public void complete() {
+        this.status = state.complete();
+        this.state = ReservationStateFactory.from(this.status);
+        this.checkedInAt = LocalDateTime.now();
+    }
+
+    public void markNoShow() {
+        this.status = state.markNoShow();
+        this.state = ReservationStateFactory.from(this.status);
+    }
+
+    public boolean requiresSlotReturn() {
+        return state.requiresSlotReturn();
+    }
+
+    public boolean isCancellable() {
+        return state.status() == ReservationStatus.CONFIRMED
+                && !LocalDate.now().isAfter(cancelDeadline);
+    }
+
+    public boolean isModifiable() {
+        return state.status() == ReservationStatus.CONFIRMED
+                && !LocalDate.now().isAfter(modifyDeadline);
+    }
+
+    public boolean requiresRefund() {
+        return state.requiresRefund();
+    }
+
+    public void modify(
+            UUID newTimeSlotId,
+            LocalDate newReservedDate,
+            GuestCount newGuestCount,
+            LocalDateTime newNoshowDeadline
+    ) {
+        if (state.status() != ReservationStatus.CONFIRMED) {
+            throw new BusinessException(ReservationErrorCode.INVALID_STATUS_TRANSITION);
+        }
+        if (LocalDate.now().isAfter(modifyDeadline)) {
+            throw new BusinessException(ReservationErrorCode.MODIFY_DEADLINE_EXCEEDED);
+        }
+        this.timeSlotId = newTimeSlotId;
+        this.reservedDate = newReservedDate;
+        this.guestCount = newGuestCount;
+        this.cancelDeadline = newReservedDate.minusDays(2);
+        this.modifyDeadline = newReservedDate.minusDays(2);
+        this.noshowDeadline = newNoshowDeadline;
+    }
+
+    private static void validateCreateInput(
+            UUID userId,
+            UUID restaurantId,
+            UUID timeSlotId,
+            LocalDate reservedDate,
+            GuestCount guestCount) {
+        if (userId == null) {
+            throw new BusinessException(ReservationErrorCode.INVALID_USER_ID);
+        }
+        if (restaurantId == null) {
+            throw new BusinessException(ReservationErrorCode.INVALID_RESTAURANT_ID);
+        }
+        if (timeSlotId == null) {
+            throw new BusinessException(ReservationErrorCode.INVALID_TIME_SLOT_ID);
+        }
+        if (reservedDate == null) {
+            throw new BusinessException(ReservationErrorCode.INVALID_RESERVED_DATE);
+        }
+        if (guestCount == null) {
+            throw new BusinessException(ReservationErrorCode.INVALID_GUEST_COUNT_NULL);
+        }
+    }
+
+    private static void validateReconstituteInput(
+            UUID id,
+            UUID userId,
+            UUID restaurantId,
+            UUID timeSlotId,
+            LocalDate reservedDate,
+            GuestCount guestCount,
+            ReservationStatus status
+    ) {
+        if (id == null) {
+            throw new BusinessException(ReservationErrorCode.RESERVATION_NOT_FOUND);
+        }
+        if (userId == null) {
+            throw new BusinessException(ReservationErrorCode.INVALID_USER_ID);
+        }
+        if (restaurantId == null) {
+            throw new BusinessException(ReservationErrorCode.INVALID_RESTAURANT_ID);
+        }
+        if (timeSlotId == null) {
+            throw new BusinessException(ReservationErrorCode.INVALID_TIME_SLOT_ID);
+        }
+        if (reservedDate == null) {
+            throw new BusinessException(ReservationErrorCode.INVALID_RESERVED_DATE);
+        }
+        if (guestCount == null) {
+            throw new BusinessException(ReservationErrorCode.INVALID_GUEST_COUNT_NULL);
+        }
+        if (status == null) {
+            throw new BusinessException(ReservationErrorCode.INVALID_STATUS);
+        }
+    }
 }

--- a/src/main/java/com/michelet/reservation/domain/enums/ReservationTransition.java
+++ b/src/main/java/com/michelet/reservation/domain/enums/ReservationTransition.java
@@ -1,0 +1,27 @@
+package com.michelet.reservation.domain.enums;
+
+import java.util.Arrays;
+
+public enum ReservationTransition {
+
+    WAITING_TO_CONFIRMED        (ReservationStatus.WAITING,   ReservationStatus.CONFIRMED),
+    WAITING_TO_CANCELLED_UNPAID (ReservationStatus.WAITING,   ReservationStatus.CANCELLED_UNPAID),
+    CONFIRMED_TO_CANCELLED_PAID (ReservationStatus.CONFIRMED, ReservationStatus.CANCELLED_PAID),
+    CONFIRMED_TO_COMPLETED      (ReservationStatus.CONFIRMED, ReservationStatus.COMPLETED),
+    CONFIRMED_TO_NO_SHOW        (ReservationStatus.CONFIRMED, ReservationStatus.NO_SHOW);
+
+    private final ReservationStatus from;
+    private final ReservationStatus to;
+
+    ReservationTransition(ReservationStatus from, ReservationStatus to) {
+        this.from = from;
+        this.to   = to;
+    }
+
+    public ReservationStatus from() { return from; }
+    public ReservationStatus to()   { return to; }
+
+    public static boolean isAllowed(ReservationStatus from, ReservationStatus to) {
+        return Arrays.stream(values()).anyMatch(t -> t.from == from && t.to == to);
+    }
+}

--- a/src/main/java/com/michelet/reservation/domain/exception/ReservationErrorCode.java
+++ b/src/main/java/com/michelet/reservation/domain/exception/ReservationErrorCode.java
@@ -24,6 +24,7 @@ public enum ReservationErrorCode implements ErrorCode {
   INVALID_TIME_SLOT_ID            ("RESERVATION_010", "타임슬롯 ID는 필수입니다.", 400),
   INVALID_RESERVED_DATE           ("RESERVATION_011", "예약일은 필수입니다.", 400),
   INVALID_GUEST_COUNT_NULL        ("RESERVATION_012", "인원수는 필수입니다.", 400),
+  INVALID_STATUS                  ("RESERVATION_015", "예약 상태 정보는 필수입니다.", 400),
 
   INVALID_GUEST_COUNT             ("RESERVATION_013", "인원수는 1명 이상 20명 이하여야 합니다.", 400),
   SLOT_START_TIME_REQUIRED        ("RESERVATION_014", "타임슬롯 변경 시 슬롯 시작 시각은 필수입니다.", 400),

--- a/src/main/java/com/michelet/reservation/domain/state/CancelledPaidState.java
+++ b/src/main/java/com/michelet/reservation/domain/state/CancelledPaidState.java
@@ -1,0 +1,15 @@
+package com.michelet.reservation.domain.state;
+
+import com.michelet.reservation.domain.enums.ReservationStatus;
+
+public class CancelledPaidState implements ReservationState {
+
+    @Override
+    public boolean requiresSlotReturn() { return false; }
+
+    @Override
+    public boolean requiresRefund() { return true; }
+
+    @Override
+    public ReservationStatus status() { return ReservationStatus.CANCELLED_PAID; }
+}

--- a/src/main/java/com/michelet/reservation/domain/state/CancelledUnpaidState.java
+++ b/src/main/java/com/michelet/reservation/domain/state/CancelledUnpaidState.java
@@ -1,0 +1,15 @@
+package com.michelet.reservation.domain.state;
+
+import com.michelet.reservation.domain.enums.ReservationStatus;
+
+public class CancelledUnpaidState implements ReservationState {
+
+    @Override
+    public boolean requiresSlotReturn() { return false; }
+
+    @Override
+    public boolean requiresRefund() { return false; }
+
+    @Override
+    public ReservationStatus status() { return ReservationStatus.CANCELLED_UNPAID; }
+}

--- a/src/main/java/com/michelet/reservation/domain/state/CompletedState.java
+++ b/src/main/java/com/michelet/reservation/domain/state/CompletedState.java
@@ -1,0 +1,15 @@
+package com.michelet.reservation.domain.state;
+
+import com.michelet.reservation.domain.enums.ReservationStatus;
+
+public class CompletedState implements ReservationState {
+
+    @Override
+    public boolean requiresSlotReturn() { return false; }
+
+    @Override
+    public boolean requiresRefund() { return false; }
+
+    @Override
+    public ReservationStatus status() { return ReservationStatus.COMPLETED; }
+}

--- a/src/main/java/com/michelet/reservation/domain/state/ConfirmedState.java
+++ b/src/main/java/com/michelet/reservation/domain/state/ConfirmedState.java
@@ -1,0 +1,36 @@
+package com.michelet.reservation.domain.state;
+
+import com.michelet.common.exception.BusinessException;
+import com.michelet.reservation.domain.enums.ReservationStatus;
+import com.michelet.reservation.domain.exception.ReservationErrorCode;
+import java.time.LocalDate;
+
+public class ConfirmedState implements ReservationState {
+
+    @Override
+    public ReservationStatus cancel(LocalDate cancelDeadline) {
+        if (LocalDate.now().isAfter(cancelDeadline)) {
+            throw new BusinessException(ReservationErrorCode.CANCEL_DEADLINE_EXCEEDED);
+        }
+        return ReservationStatus.CANCELLED_PAID;
+    }
+
+    @Override
+    public ReservationStatus complete() {
+        return ReservationStatus.COMPLETED;
+    }
+
+    @Override
+    public ReservationStatus markNoShow() {
+        return ReservationStatus.NO_SHOW;
+    }
+
+    @Override
+    public boolean requiresSlotReturn() { return true; }
+
+    @Override
+    public boolean requiresRefund() { return false; }
+
+    @Override
+    public ReservationStatus status() { return ReservationStatus.CONFIRMED; }
+}

--- a/src/main/java/com/michelet/reservation/domain/state/NoShowState.java
+++ b/src/main/java/com/michelet/reservation/domain/state/NoShowState.java
@@ -1,0 +1,15 @@
+package com.michelet.reservation.domain.state;
+
+import com.michelet.reservation.domain.enums.ReservationStatus;
+
+public class NoShowState implements ReservationState {
+
+    @Override
+    public boolean requiresSlotReturn() { return false; }
+
+    @Override
+    public boolean requiresRefund() { return false; }
+
+    @Override
+    public ReservationStatus status() { return ReservationStatus.NO_SHOW; }
+}

--- a/src/main/java/com/michelet/reservation/domain/state/ReservationState.java
+++ b/src/main/java/com/michelet/reservation/domain/state/ReservationState.java
@@ -1,0 +1,35 @@
+package com.michelet.reservation.domain.state;
+
+import com.michelet.common.exception.BusinessException;
+import com.michelet.reservation.domain.enums.ReservationStatus;
+import com.michelet.reservation.domain.exception.ReservationErrorCode;
+import java.time.LocalDate;
+
+public interface ReservationState {
+
+    // 전이 메서드 — 허용하지 않는 전이는 default에서 예외를 던진다
+    default ReservationStatus confirm() {
+        throw new BusinessException(ReservationErrorCode.INVALID_STATUS_TRANSITION);
+    }
+
+    default ReservationStatus cancel(LocalDate cancelDeadline) {
+        throw new BusinessException(ReservationErrorCode.INVALID_STATUS_TRANSITION);
+    }
+
+    default ReservationStatus cancelUnpaid() {
+        throw new BusinessException(ReservationErrorCode.INVALID_STATUS_TRANSITION);
+    }
+
+    default ReservationStatus complete() {
+        throw new BusinessException(ReservationErrorCode.INVALID_STATUS_TRANSITION);
+    }
+
+    default ReservationStatus markNoShow() {
+        throw new BusinessException(ReservationErrorCode.INVALID_STATUS_TRANSITION);
+    }
+
+    // 정책 메서드 — 상태별 구현 필수
+    boolean requiresSlotReturn();
+    boolean requiresRefund();
+    ReservationStatus status();
+}

--- a/src/main/java/com/michelet/reservation/domain/state/ReservationStateFactory.java
+++ b/src/main/java/com/michelet/reservation/domain/state/ReservationStateFactory.java
@@ -1,0 +1,20 @@
+package com.michelet.reservation.domain.state;
+
+import com.michelet.reservation.domain.enums.ReservationStatus;
+
+public class ReservationStateFactory {
+
+    private ReservationStateFactory() {}
+
+    // 신규 enum 값 추가 시 컴파일 에러로 누락을 방지하기 위해 exhaustive switch 사용
+    public static ReservationState from(ReservationStatus status) {
+        return switch (status) {
+            case WAITING          -> new WaitingState();
+            case CONFIRMED        -> new ConfirmedState();
+            case CANCELLED_UNPAID -> new CancelledUnpaidState();
+            case CANCELLED_PAID   -> new CancelledPaidState();
+            case COMPLETED        -> new CompletedState();
+            case NO_SHOW          -> new NoShowState();
+        };
+    }
+}

--- a/src/main/java/com/michelet/reservation/domain/state/ReservationStateFactory.java
+++ b/src/main/java/com/michelet/reservation/domain/state/ReservationStateFactory.java
@@ -1,6 +1,8 @@
 package com.michelet.reservation.domain.state;
 
+import com.michelet.common.exception.BusinessException;
 import com.michelet.reservation.domain.enums.ReservationStatus;
+import com.michelet.reservation.domain.exception.ReservationErrorCode;
 
 public class ReservationStateFactory {
 
@@ -8,6 +10,9 @@ public class ReservationStateFactory {
 
     // 신규 enum 값 추가 시 컴파일 에러로 누락을 방지하기 위해 exhaustive switch 사용
     public static ReservationState from(ReservationStatus status) {
+        if (status == null) {
+            throw new BusinessException(ReservationErrorCode.INVALID_STATUS);
+        }
         return switch (status) {
             case WAITING          -> new WaitingState();
             case CONFIRMED        -> new ConfirmedState();

--- a/src/main/java/com/michelet/reservation/domain/state/WaitingState.java
+++ b/src/main/java/com/michelet/reservation/domain/state/WaitingState.java
@@ -1,0 +1,25 @@
+package com.michelet.reservation.domain.state;
+
+import com.michelet.reservation.domain.enums.ReservationStatus;
+
+public class WaitingState implements ReservationState {
+
+    @Override
+    public ReservationStatus confirm() {
+        return ReservationStatus.CONFIRMED;
+    }
+
+    @Override
+    public ReservationStatus cancelUnpaid() {
+        return ReservationStatus.CANCELLED_UNPAID;
+    }
+
+    @Override
+    public boolean requiresSlotReturn() { return false; }
+
+    @Override
+    public boolean requiresRefund() { return false; }
+
+    @Override
+    public ReservationStatus status() { return ReservationStatus.WAITING; }
+}

--- a/src/main/java/com/michelet/reservation/infrastructure/reservation/entity/ReservationJpaEntity.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/reservation/entity/ReservationJpaEntity.java
@@ -80,10 +80,6 @@ public class ReservationJpaEntity  extends BaseJpaEntity {
     return e;
   }
 
-  public void updateStatus(ReservationStatus status) {
-    this.status = status;
-  }
-
   public void updateSchedule(
       LocalDate reservedDate, int guestCount,
       LocalDate cancelDeadline, LocalDate modifyDeadline, LocalDateTime noshowDeadline

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:create}
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
@@ -41,7 +41,7 @@ spring:
 #
 internal:
   auth:
-    secret: ${INTERNAL_AUTH_SECRET:michelet-internal-auth-secret-key-a8K2mQ9xLp4Vt7Rz1Nc}
+    secret: ${INTERNAL_AUTH_SECRET}
 
 feign:
   timeslot-service:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:create}
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
@@ -23,25 +23,25 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
 
-  kafka:
-    bootstrap-servers: ${KAFKA_HOST}:${KAFKA_PORT}
-    producer:
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-      properties:
-        spring.json.add.type.headers: false
+#  kafka:
+#    bootstrap-servers: ${KAFKA_HOST}:${KAFKA_PORT}
+#    producer:
+#      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+#      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+#      properties:
+#        spring.json.add.type.headers: false
 
-  cloud:
-    discovery:
-      enabled: true
-eureka:
-  client:
-    service-url:
-      defaultZone: http://${EUREKA_HOST:localhost}:${EUREKA_PORT:19090}/eureka/
-
+#  cloud:
+#    discovery:
+#      enabled: true
+#eureka:
+#  client:
+#    service-url:
+#      defaultZone: http://${EUREKA_HOST:localhost}:${EUREKA_PORT:19090}/eureka/
+#
 internal:
   auth:
-    secret: ${INTERNAL_AUTH_SECRET}
+    secret: ${INTERNAL_AUTH_SECRET:michelet-internal-auth-secret-key-a8K2mQ9xLp4Vt7Rz1Nc}
 
 feign:
   timeslot-service:

--- a/src/test/java/com/michelet/reservation/domain/entity/ReservationTest.java
+++ b/src/test/java/com/michelet/reservation/domain/entity/ReservationTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.michelet.common.exception.BusinessException;
 import com.michelet.reservation.domain.enums.ReservationStatus;
-import com.michelet.reservation.domain.enums.ReservationTransition;
 import com.michelet.reservation.domain.exception.ReservationErrorCode;
 import com.michelet.reservation.domain.vo.GuestCount;
 import java.time.LocalDate;

--- a/src/test/java/com/michelet/reservation/domain/entity/ReservationTest.java
+++ b/src/test/java/com/michelet/reservation/domain/entity/ReservationTest.java
@@ -211,6 +211,83 @@ class ReservationTest {
     }
 
     @Nested
+    class PolicyMethods {
+
+        @Test
+        void CONFIRMED_상태에서_requiresSlotReturn은_true다() {
+            assertThat(confirmedFuture().requiresSlotReturn()).isTrue();
+        }
+
+        @Test
+        void WAITING_상태에서_requiresSlotReturn은_false다() {
+            assertThat(waitingFuture().requiresSlotReturn()).isFalse();
+        }
+
+        @Test
+        void COMPLETED_상태에서_requiresSlotReturn은_false다() {
+            Reservation r = confirmedFuture();
+            r.complete();
+            assertThat(r.requiresSlotReturn()).isFalse();
+        }
+
+        @Test
+        void CANCELLED_PAID_상태에서_requiresSlotReturn은_false다() {
+            Reservation r = confirmedFuture();
+            r.cancel();
+            assertThat(r.requiresSlotReturn()).isFalse();
+        }
+
+        @Test
+        void CONFIRMED_deadline_이내에서_isCancellable은_true다() {
+            assertThat(confirmedFuture().isCancellable()).isTrue();
+        }
+
+        @Test
+        void CONFIRMED_deadline_초과_시_isCancellable은_false다() {
+            assertThat(confirmedDeadlinePassed().isCancellable()).isFalse();
+        }
+
+        @Test
+        void WAITING_상태에서_isCancellable은_false다() {
+            assertThat(waitingFuture().isCancellable()).isFalse();
+        }
+
+        @Test
+        void CONFIRMED_deadline_이내에서_isModifiable은_true다() {
+            assertThat(confirmedFuture().isModifiable()).isTrue();
+        }
+
+        @Test
+        void CONFIRMED_deadline_초과_시_isModifiable은_false다() {
+            assertThat(confirmedDeadlinePassed().isModifiable()).isFalse();
+        }
+
+        @Test
+        void WAITING_상태에서_isModifiable은_false다() {
+            assertThat(waitingFuture().isModifiable()).isFalse();
+        }
+
+        @Test
+        void CANCELLED_PAID_상태에서_requiresRefund는_true다() {
+            Reservation r = confirmedFuture();
+            r.cancel();
+            assertThat(r.requiresRefund()).isTrue();
+        }
+
+        @Test
+        void CONFIRMED_상태에서_requiresRefund는_false다() {
+            assertThat(confirmedFuture().requiresRefund()).isFalse();
+        }
+
+        @Test
+        void CANCELLED_UNPAID_상태에서_requiresRefund는_false다() {
+            Reservation r = waitingFuture();
+            r.cancelUnpaid();
+            assertThat(r.requiresRefund()).isFalse();
+        }
+    }
+
+    @Nested
     class ForbiddenTransitions {
 
         @Test

--- a/src/test/java/com/michelet/reservation/domain/entity/ReservationTest.java
+++ b/src/test/java/com/michelet/reservation/domain/entity/ReservationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.michelet.common.exception.BusinessException;
 import com.michelet.reservation.domain.enums.ReservationStatus;
+import com.michelet.reservation.domain.enums.ReservationTransition;
 import com.michelet.reservation.domain.exception.ReservationErrorCode;
 import com.michelet.reservation.domain.vo.GuestCount;
 import java.time.LocalDate;
@@ -203,6 +204,64 @@ class ReservationTest {
             r.cancel();
 
             assertThatThrownBy(r::markNoShow)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.INVALID_STATUS_TRANSITION.getCode()));
+        }
+    }
+
+    @Nested
+    class ForbiddenTransitions {
+
+        @Test
+        void COMPLETED_상태에서_confirm_호출_시_예외를_던진다() {
+            Reservation r = confirmedFuture();
+            r.complete();
+
+            assertThatThrownBy(r::confirm)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.INVALID_STATUS_TRANSITION.getCode()));
+        }
+
+        @Test
+        void NO_SHOW_상태에서_cancel_호출_시_예외를_던진다() {
+            Reservation r = confirmedFuture();
+            r.markNoShow();
+
+            assertThatThrownBy(r::cancel)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.INVALID_STATUS_TRANSITION.getCode()));
+        }
+
+        @Test
+        void CANCELLED_PAID_상태에서_complete_호출_시_예외를_던진다() {
+            Reservation r = confirmedFuture();
+            r.cancel();
+
+            assertThatThrownBy(r::complete)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.INVALID_STATUS_TRANSITION.getCode()));
+        }
+
+        @Test
+        void WAITING_상태에서_cancel_호출_시_예외를_던진다() {
+            Reservation r = waitingFuture();
+
+            assertThatThrownBy(r::cancel)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.INVALID_STATUS_TRANSITION.getCode()));
+        }
+
+        @Test
+        void CANCELLED_UNPAID_상태에서_cancelUnpaid_호출_시_예외를_던진다() {
+            Reservation r = waitingFuture();
+            r.cancelUnpaid();
+
+            assertThatThrownBy(r::cancelUnpaid)
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ReservationErrorCode.INVALID_STATUS_TRANSITION.getCode()));

--- a/src/test/java/com/michelet/reservation/domain/enums/ReservationTransitionTest.java
+++ b/src/test/java/com/michelet/reservation/domain/enums/ReservationTransitionTest.java
@@ -1,0 +1,104 @@
+package com.michelet.reservation.domain.enums;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ReservationTransitionTest {
+
+    @Nested
+    class AllowedTransitions {
+
+        @Test
+        void WAITING에서_CONFIRMED로_전이_허용() {
+            assertThat(ReservationTransition.isAllowed(ReservationStatus.WAITING, ReservationStatus.CONFIRMED)).isTrue();
+        }
+
+        @Test
+        void WAITING에서_CANCELLED_UNPAID로_전이_허용() {
+            assertThat(ReservationTransition.isAllowed(ReservationStatus.WAITING, ReservationStatus.CANCELLED_UNPAID)).isTrue();
+        }
+
+        @Test
+        void CONFIRMED에서_CANCELLED_PAID로_전이_허용() {
+            assertThat(ReservationTransition.isAllowed(ReservationStatus.CONFIRMED, ReservationStatus.CANCELLED_PAID)).isTrue();
+        }
+
+        @Test
+        void CONFIRMED에서_COMPLETED로_전이_허용() {
+            assertThat(ReservationTransition.isAllowed(ReservationStatus.CONFIRMED, ReservationStatus.COMPLETED)).isTrue();
+        }
+
+        @Test
+        void CONFIRMED에서_NO_SHOW로_전이_허용() {
+            assertThat(ReservationTransition.isAllowed(ReservationStatus.CONFIRMED, ReservationStatus.NO_SHOW)).isTrue();
+        }
+    }
+
+    @Nested
+    class ForbiddenTransitions {
+
+        @Test
+        void CONFIRMED에서_WAITING으로_전이_금지() {
+            assertThat(ReservationTransition.isAllowed(ReservationStatus.CONFIRMED, ReservationStatus.WAITING)).isFalse();
+        }
+
+        @Test
+        void CONFIRMED에서_CONFIRMED로_전이_금지() {
+            assertThat(ReservationTransition.isAllowed(ReservationStatus.CONFIRMED, ReservationStatus.CONFIRMED)).isFalse();
+        }
+
+        @Test
+        void COMPLETED에서_CONFIRMED로_전이_금지() {
+            assertThat(ReservationTransition.isAllowed(ReservationStatus.COMPLETED, ReservationStatus.CONFIRMED)).isFalse();
+        }
+
+        @Test
+        void NO_SHOW에서_CONFIRMED로_전이_금지() {
+            assertThat(ReservationTransition.isAllowed(ReservationStatus.NO_SHOW, ReservationStatus.CONFIRMED)).isFalse();
+        }
+
+        @Test
+        void CANCELLED_PAID에서_CONFIRMED로_전이_금지() {
+            assertThat(ReservationTransition.isAllowed(ReservationStatus.CANCELLED_PAID, ReservationStatus.CONFIRMED)).isFalse();
+        }
+
+        @Test
+        void CANCELLED_UNPAID에서_CONFIRMED로_전이_금지() {
+            assertThat(ReservationTransition.isAllowed(ReservationStatus.CANCELLED_UNPAID, ReservationStatus.CONFIRMED)).isFalse();
+        }
+
+        @Test
+        void WAITING에서_CANCELLED_PAID로_전이_금지() {
+            assertThat(ReservationTransition.isAllowed(ReservationStatus.WAITING, ReservationStatus.CANCELLED_PAID)).isFalse();
+        }
+
+        @Test
+        void WAITING에서_COMPLETED로_전이_금지() {
+            assertThat(ReservationTransition.isAllowed(ReservationStatus.WAITING, ReservationStatus.COMPLETED)).isFalse();
+        }
+
+        @Test
+        void WAITING에서_NO_SHOW로_전이_금지() {
+            assertThat(ReservationTransition.isAllowed(ReservationStatus.WAITING, ReservationStatus.NO_SHOW)).isFalse();
+        }
+    }
+
+    @Nested
+    class TransitionCount {
+
+        @Test
+        void 허용_전이는_정확히_5개다() {
+            long count = 0;
+            for (ReservationStatus from : ReservationStatus.values()) {
+                for (ReservationStatus to : ReservationStatus.values()) {
+                    if (ReservationTransition.isAllowed(from, to)) {
+                        count++;
+                    }
+                }
+            }
+            assertThat(count).isEqualTo(5);
+        }
+    }
+}

--- a/src/test/java/com/michelet/reservation/domain/state/ReservationStateTest.java
+++ b/src/test/java/com/michelet/reservation/domain/state/ReservationStateTest.java
@@ -1,0 +1,234 @@
+package com.michelet.reservation.domain.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.michelet.common.exception.BusinessException;
+import com.michelet.reservation.domain.enums.ReservationStatus;
+import com.michelet.reservation.domain.exception.ReservationErrorCode;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ReservationStateTest {
+
+    final LocalDate futureDeadline = LocalDate.now().plusDays(5);
+    final LocalDate pastDeadline   = LocalDate.now().minusDays(1);
+
+    // ─────────────────────── Factory ───────────────────────
+
+    @Nested
+    class Factory {
+
+        @Test
+        void 각_상태값에_대해_올바른_구현체를_반환한다() {
+            assertThat(ReservationStateFactory.from(ReservationStatus.WAITING))
+                    .isInstanceOf(WaitingState.class);
+            assertThat(ReservationStateFactory.from(ReservationStatus.CONFIRMED))
+                    .isInstanceOf(ConfirmedState.class);
+            assertThat(ReservationStateFactory.from(ReservationStatus.CANCELLED_UNPAID))
+                    .isInstanceOf(CancelledUnpaidState.class);
+            assertThat(ReservationStateFactory.from(ReservationStatus.CANCELLED_PAID))
+                    .isInstanceOf(CancelledPaidState.class);
+            assertThat(ReservationStateFactory.from(ReservationStatus.COMPLETED))
+                    .isInstanceOf(CompletedState.class);
+            assertThat(ReservationStateFactory.from(ReservationStatus.NO_SHOW))
+                    .isInstanceOf(NoShowState.class);
+        }
+
+        @Test
+        void 모든_enum_값에_대해_누락_없이_구현체를_반환한다() {
+            for (ReservationStatus status : ReservationStatus.values()) {
+                assertThat(ReservationStateFactory.from(status)).isNotNull();
+            }
+        }
+    }
+
+    // ─────────────────────── WaitingState ───────────────────────
+
+    @Nested
+    class Waiting {
+
+        final ReservationState state = new WaitingState();
+
+        @Test
+        void confirm은_CONFIRMED를_반환한다() {
+            assertThat(state.confirm()).isEqualTo(ReservationStatus.CONFIRMED);
+        }
+
+        @Test
+        void cancelUnpaid는_CANCELLED_UNPAID를_반환한다() {
+            assertThat(state.cancelUnpaid()).isEqualTo(ReservationStatus.CANCELLED_UNPAID);
+        }
+
+        @Test
+        void cancel은_예외를_던진다() {
+            assertThatThrownBy(() -> state.cancel(futureDeadline))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.INVALID_STATUS_TRANSITION.getCode()));
+        }
+
+        @Test
+        void complete는_예외를_던진다() {
+            assertThatThrownBy(state::complete)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.INVALID_STATUS_TRANSITION.getCode()));
+        }
+
+        @Test
+        void markNoShow는_예외를_던진다() {
+            assertThatThrownBy(state::markNoShow)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.INVALID_STATUS_TRANSITION.getCode()));
+        }
+
+        @Test
+        void requiresSlotReturn은_false다() {
+            assertThat(state.requiresSlotReturn()).isFalse();
+        }
+
+        @Test
+        void requiresRefund는_false다() {
+            assertThat(state.requiresRefund()).isFalse();
+        }
+
+        @Test
+        void status는_WAITING이다() {
+            assertThat(state.status()).isEqualTo(ReservationStatus.WAITING);
+        }
+    }
+
+    // ─────────────────────── ConfirmedState ───────────────────────
+
+    @Nested
+    class Confirmed {
+
+        final ReservationState state = new ConfirmedState();
+
+        @Test
+        void deadline_이내에서_cancel은_CANCELLED_PAID를_반환한다() {
+            assertThat(state.cancel(futureDeadline)).isEqualTo(ReservationStatus.CANCELLED_PAID);
+        }
+
+        @Test
+        void deadline_초과_시_cancel은_CANCEL_DEADLINE_EXCEEDED_예외를_던진다() {
+            assertThatThrownBy(() -> state.cancel(pastDeadline))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.CANCEL_DEADLINE_EXCEEDED.getCode()));
+        }
+
+        @Test
+        void complete는_COMPLETED를_반환한다() {
+            assertThat(state.complete()).isEqualTo(ReservationStatus.COMPLETED);
+        }
+
+        @Test
+        void markNoShow는_NO_SHOW를_반환한다() {
+            assertThat(state.markNoShow()).isEqualTo(ReservationStatus.NO_SHOW);
+        }
+
+        @Test
+        void confirm은_예외를_던진다() {
+            assertThatThrownBy(state::confirm)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.INVALID_STATUS_TRANSITION.getCode()));
+        }
+
+        @Test
+        void cancelUnpaid는_예외를_던진다() {
+            assertThatThrownBy(state::cancelUnpaid)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.INVALID_STATUS_TRANSITION.getCode()));
+        }
+
+        @Test
+        void requiresSlotReturn은_true다() {
+            assertThat(state.requiresSlotReturn()).isTrue();
+        }
+
+        @Test
+        void requiresRefund는_false다() {
+            assertThat(state.requiresRefund()).isFalse();
+        }
+
+        @Test
+        void status는_CONFIRMED다() {
+            assertThat(state.status()).isEqualTo(ReservationStatus.CONFIRMED);
+        }
+    }
+
+    // ─────────────────────── Terminal States ───────────────────────
+
+    @Nested
+    class TerminalStates {
+
+        @Test
+        void CancelledUnpaid_모든_전이_메서드가_예외를_던진다() {
+            ReservationState state = new CancelledUnpaidState();
+            assertAllTransitionsForbidden(state);
+            assertThat(state.requiresSlotReturn()).isFalse();
+            assertThat(state.requiresRefund()).isFalse();
+            assertThat(state.status()).isEqualTo(ReservationStatus.CANCELLED_UNPAID);
+        }
+
+        @Test
+        void CancelledPaid_모든_전이_메서드가_예외를_던진다() {
+            ReservationState state = new CancelledPaidState();
+            assertAllTransitionsForbidden(state);
+            assertThat(state.requiresSlotReturn()).isFalse();
+            assertThat(state.requiresRefund()).isTrue();
+            assertThat(state.status()).isEqualTo(ReservationStatus.CANCELLED_PAID);
+        }
+
+        @Test
+        void Completed_모든_전이_메서드가_예외를_던진다() {
+            ReservationState state = new CompletedState();
+            assertAllTransitionsForbidden(state);
+            assertThat(state.requiresSlotReturn()).isFalse();
+            assertThat(state.requiresRefund()).isFalse();
+            assertThat(state.status()).isEqualTo(ReservationStatus.COMPLETED);
+        }
+
+        @Test
+        void NoShow_모든_전이_메서드가_예외를_던진다() {
+            ReservationState state = new NoShowState();
+            assertAllTransitionsForbidden(state);
+            assertThat(state.requiresSlotReturn()).isFalse();
+            assertThat(state.requiresRefund()).isFalse();
+            assertThat(state.status()).isEqualTo(ReservationStatus.NO_SHOW);
+        }
+
+        private void assertAllTransitionsForbidden(ReservationState state) {
+            assertThatThrownBy(state::confirm)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.INVALID_STATUS_TRANSITION.getCode()));
+
+            assertThatThrownBy(() -> state.cancel(futureDeadline))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.INVALID_STATUS_TRANSITION.getCode()));
+
+            assertThatThrownBy(state::cancelUnpaid)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.INVALID_STATUS_TRANSITION.getCode()));
+
+            assertThatThrownBy(state::complete)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.INVALID_STATUS_TRANSITION.getCode()));
+
+            assertThatThrownBy(state::markNoShow)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.INVALID_STATUS_TRANSITION.getCode()));
+        }
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 상태변경 주체 도메인에 위임
- state pattern 적용

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #34   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.
<img width="2618" height="322" alt="image" src="https://github.com/user-attachments/assets/d3997cb3-4a2a-4de5-a066-cac636f2368e" />


<img width="1126" height="632" alt="image" src="https://github.com/user-attachments/assets/04947a42-5767-4cc8-9381-f147329668ed" />

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Java 도구체인 레벨을 21→17로 변경
  * 공통 인증 라이브러리 버전 업데이트(0.1.1→0.1.2)
  * 서비스 디스커버리(Eureka) 및 Kafka 설정 비활성화

* **New Features**
  * 예약 상태 처리를 상태 객체 기반으로 재구성하여 상태별 정책(환불·슬롯 반환 등) 명확화

* **Bug Fixes**
  * 잘못된 상태 전환 차단 강화 및 삭제 시 슬롯 반환 조건 정교화

* **Tests**
  * 상태/전환 관련 단위 테스트 대폭 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/reservation-service/pull/35)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->