### PR TITLE
[refactor] fegin 호출 신뢰성 문제 임시 해결

### DIFF
--- a/src/main/java/com/michelet/reservation/application/exception/ExternalCallFailedException.java
+++ b/src/main/java/com/michelet/reservation/application/exception/ExternalCallFailedException.java
@@ -1,0 +1,12 @@
+package com.michelet.reservation.application.exception;
+
+/**
+ * 외부 서비스 호출 결과를 확인할 수 없는 상황 — 타임아웃, 네트워크 단절, 5xx 서버 오류.
+ * 이 예외가 발생하면 외부 서비스의 처리 여부를 알 수 없으므로 예약은 WAITING으로 유지되며 재처리 대상이 된다.
+ */
+public class ExternalCallFailedException extends RuntimeException {
+
+    public ExternalCallFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/michelet/reservation/application/port/TimeSlotPort.java
+++ b/src/main/java/com/michelet/reservation/application/port/TimeSlotPort.java
@@ -3,6 +3,11 @@ package com.michelet.reservation.application.port;
 import java.util.UUID;
 
 public interface TimeSlotPort {
-    void decrementStock(UUID timeSlotId, int requiredCapacity);
+
+    /**
+     * @param reservationId 멱등성 키 — 네트워크 재전송 시 이중 차감 방지용 (X-Idempotency-Key 헤더로 전달)
+     */
+    void decrementStock(UUID timeSlotId, int requiredCapacity, UUID reservationId);
+
     void incrementStock(UUID timeSlotId, int requiredCapacity);
 }

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
@@ -2,6 +2,7 @@ package com.michelet.reservation.application.reservation;
 
 import com.michelet.common.exception.BusinessException;
 import com.michelet.reservation.application.event.ReservationCreatedAppEvent;
+import com.michelet.reservation.application.exception.ExternalCallFailedException;
 import com.michelet.reservation.application.reservation.command.CancelReservationCommand;
 import com.michelet.reservation.application.reservation.command.CheckInCommand;
 import com.michelet.reservation.application.reservation.command.CreateReservationCommand;
@@ -26,10 +27,12 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -66,11 +69,24 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
         Reservation saved = reservationRepository.save(reservation);
         List<ReservationCourse> savedCourses = saveCourses(saved.getId(), command.courses());
 
-        // 타임슬롯 점유 및 대기열 완료 처리
-        // feign 성공 확인 후 CONFIRMED 전환 — 실패 시 트랜잭션 롤백으로 WAITING 레코드 제거
-        // TODO: 진정한 내결함성을 위해서는 WAITING 별도 커밋 + outbox 패턴 적용 필요 (다음 PR)
-        timeSlotPort.decrementStock(saved.getTimeSlotId(), saved.getGuestCount().value());
-        waitingPort.completeWaiting(tokenResult.waitingId());
+        // Phase 1: 슬롯 차감 — 실패 시 WAITING 유지 (트랜잭션 커밋)
+        // 비즈니스 거부(슬롯 부족 등)는 BusinessException 전파 → 트랜잭션 롤백
+        // TODO: Outbox 패턴 도입 후 WAITING 예약 자동 재처리 스케줄러 구현 필요
+        try {
+            timeSlotPort.decrementStock(saved.getTimeSlotId(), saved.getGuestCount().value(), saved.getId());
+        } catch (ExternalCallFailedException e) {
+            log.warn("[create] timeslot-service 호출 실패 — 예약 WAITING 유지 (reservationId={})", saved.getId(), e);
+            return toResult(saved, savedCourses);
+        }
+
+        // Phase 2: 대기열 완료 — 슬롯 차감 성공 이후이므로 실패해도 예약 확정 진행
+        // 대기열 항목은 TTL 만료 또는 운영자 정리로 처리됨
+        // TODO: WaitingAdapter에도 ExternalCallFailedException 래핑 적용 필요
+        try {
+            waitingPort.completeWaiting(tokenResult.waitingId());
+        } catch (RuntimeException e) {
+            log.warn("[create] 대기열 완료 처리 실패 — 예약 확정 계속 진행 (waitingId={})", tokenResult.waitingId(), e);
+        }
 
         saved.confirm();
         Reservation confirmed = reservationRepository.save(saved);
@@ -118,7 +134,14 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
 
         if (slotChanged) {
             timeSlotPort.incrementStock(originalTimeSlotId, originalGuestCount);
-            timeSlotPort.decrementStock(newTimeSlotId, newGuestCount);
+            try {
+                timeSlotPort.decrementStock(newTimeSlotId, newGuestCount, command.reservationId());
+            } catch (ExternalCallFailedException e) {
+                // 신규 슬롯 차감 실패 → 트랜잭션 롤백으로 예약 변경 취소
+                // 원래 슬롯 복구(incrementStock)는 현재 미구현이므로 운영자 확인 필요
+                log.error("[modify] timeslot-service 호출 실패 — 예약 변경 롤백 (reservationId={})", command.reservationId(), e);
+                throw new BusinessException(ReservationErrorCode.TIMESLOT_SERVICE_UNAVAILABLE);
+            }
         }
 
         return toResult(saved, courses);

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
@@ -133,15 +133,15 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
         List<ReservationCourse> courses = updateCourses(saved.getId(), command.courses());
 
         if (slotChanged) {
-            timeSlotPort.incrementStock(originalTimeSlotId, originalGuestCount);
+            // 신규 슬롯 차감 먼저 확인 — 실패 시 원래 슬롯 복구 없이 트랜잭션 롤백
             try {
                 timeSlotPort.decrementStock(newTimeSlotId, newGuestCount, command.reservationId());
             } catch (ExternalCallFailedException e) {
-                // 신규 슬롯 차감 실패 → 트랜잭션 롤백으로 예약 변경 취소
-                // 원래 슬롯 복구(incrementStock)는 현재 미구현이므로 운영자 확인 필요
                 log.error("[modify] timeslot-service 호출 실패 — 예약 변경 롤백 (reservationId={})", command.reservationId(), e);
                 throw new BusinessException(ReservationErrorCode.TIMESLOT_SERVICE_UNAVAILABLE);
             }
+            // 신규 슬롯 차감 성공 확인 후 원래 슬롯 복구
+            timeSlotPort.incrementStock(originalTimeSlotId, originalGuestCount);
         }
 
         return toResult(saved, courses);

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
@@ -120,6 +120,8 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
         LocalDateTime newNoshowDeadline = resolveNoshowDeadline(reservation, command.reservedDate(), command.slotStartTime(), newDate);
 
         boolean slotChanged = !newTimeSlotId.equals(originalTimeSlotId) || !newDate.equals(originalDate);
+        boolean guestCountChanged = newGuestCount != originalGuestCount;
+
         if (slotChanged) {
             // timeSlotId가 바뀌면 새 슬롯의 시작 시각이 달라질 수 있으므로 slotStartTime 필수
             if (!newTimeSlotId.equals(originalTimeSlotId) && command.slotStartTime() == null) {
@@ -133,15 +135,27 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
         List<ReservationCourse> courses = updateCourses(saved.getId(), command.courses());
 
         if (slotChanged) {
-            // 신규 슬롯 차감 먼저 확인 — 실패 시 원래 슬롯 복구 없이 트랜잭션 롤백
+            // 슬롯 변경: 새 슬롯에 새 인원 전체 차감 확인 후 원래 슬롯 복구
             try {
                 timeSlotPort.decrementStock(newTimeSlotId, newGuestCount, command.reservationId());
             } catch (ExternalCallFailedException e) {
                 log.error("[modify] timeslot-service 호출 실패 — 예약 변경 롤백 (reservationId={})", command.reservationId(), e);
                 throw new BusinessException(ReservationErrorCode.TIMESLOT_SERVICE_UNAVAILABLE);
             }
-            // 신규 슬롯 차감 성공 확인 후 원래 슬롯 복구
             timeSlotPort.incrementStock(originalTimeSlotId, originalGuestCount);
+        } else if (guestCountChanged) {
+            // 동일 슬롯에서 인원만 변경: delta(newGuestCount - originalGuestCount)만 처리
+            int delta = newGuestCount - originalGuestCount;
+            if (delta > 0) {
+                try {
+                    timeSlotPort.decrementStock(newTimeSlotId, delta, command.reservationId());
+                } catch (ExternalCallFailedException e) {
+                    log.error("[modify] 인원 증가 차감 실패 — 예약 변경 롤백 (reservationId={})", command.reservationId(), e);
+                    throw new BusinessException(ReservationErrorCode.TIMESLOT_SERVICE_UNAVAILABLE);
+                }
+            } else {
+                timeSlotPort.incrementStock(originalTimeSlotId, -delta);
+            }
         }
 
         return toResult(saved, courses);

--- a/src/main/java/com/michelet/reservation/domain/exception/ReservationErrorCode.java
+++ b/src/main/java/com/michelet/reservation/domain/exception/ReservationErrorCode.java
@@ -44,6 +44,9 @@ public enum ReservationErrorCode implements ErrorCode {
   CHECK_IN_TOO_LATE               ("RESERVATION_017", "체크인 허용 시간이 지났습니다.", 400),
   CONCURRENT_UPDATE_CONFLICT      ("RESERVATION_018", "동시 수정 요청이 충돌하였습니다. 다시 시도해 주세요.", 409),
 
+  SLOT_NOT_AVAILABLE              ("RESERVATION_019", "슬롯 잔여 인원이 부족합니다.", 409),
+  TIMESLOT_SERVICE_UNAVAILABLE    ("RESERVATION_020", "타임슬롯 서비스를 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도해 주세요.", 503),
+
   INVALID_WAITING_TOKEN           ("RESERVATION_301", "유효하지 않은 대기열 토큰입니다.", 403);
 
   private final String code;

--- a/src/main/java/com/michelet/reservation/infrastructure/client/TimeSlotClient.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/client/TimeSlotClient.java
@@ -2,21 +2,31 @@ package com.michelet.reservation.infrastructure.client;
 
 import com.michelet.common.response.ApiResponse;
 import com.michelet.reservation.infrastructure.client.dto.TimeSlotDeductCapacityRequest;
+import com.michelet.reservation.infrastructure.config.FeignTimeSlotConfig;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
-@FeignClient(name = "timeslot-service", url = "${feign.timeslot-service.url}")
+@FeignClient(
+        name = "timeslot-service",
+        url = "${feign.timeslot-service.url}",
+        configuration = FeignTimeSlotConfig.class
+)
 public interface TimeSlotClient {
 
     /**
      * 예약 확정 시 남은 수용 인원 차감. 호출 시점: create() 저장 완료 후, modify() 날짜 변경 시 신규 날짜
+     *
+     * X-Idempotency-Key: reservationId 기반 고정 키 — 네트워크 재전송 시 timeslot-service가 중복 요청을 거부할 수 있도록 함.
+     * (timeslot-service 소비 구현은 별도 PR에서 적용 예정)
      */
     @PostMapping("/internal/v1/timeslots/{timeSlotId}/deduct")
     ApiResponse<Void> decrementStock(
             @PathVariable("timeSlotId") UUID timeSlotId,
+            @RequestHeader("X-Idempotency-Key") String idempotencyKey,
             @RequestBody TimeSlotDeductCapacityRequest request
     );
 

--- a/src/main/java/com/michelet/reservation/infrastructure/client/TimeSlotClient.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/client/TimeSlotClient.java
@@ -18,10 +18,8 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public interface TimeSlotClient {
 
     /**
-     * 예약 확정 시 남은 수용 인원 차감. 호출 시점: create() 저장 완료 후, modify() 날짜 변경 시 신규 날짜
-     *
-     * X-Idempotency-Key: reservationId 기반 고정 키 — 네트워크 재전송 시 timeslot-service가 중복 요청을 거부할 수 있도록 함.
-     * (timeslot-service 소비 구현은 별도 PR에서 적용 예정)
+     * 예약 확정 시 남은 수용 인원 차감. 호출 시점: create() 저장 완료 후, modify() 날짜 변경 시 신규 날짜 X-Idempotency-Key: reservationId 기반 고정 키 —
+     * 네트워크 재전송 시 timeslot-service가 중복 요청을 거부할 수 있도록 함. (timeslot-service 소비 구현은 별도 PR에서 적용 예정)
      */
     @PostMapping("/internal/v1/timeslots/{timeSlotId}/deduct")
     ApiResponse<Void> decrementStock(

--- a/src/main/java/com/michelet/reservation/infrastructure/client/adapter/StubTimeSlotAdapter.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/client/adapter/StubTimeSlotAdapter.java
@@ -15,8 +15,9 @@ import org.springframework.stereotype.Component;
 public class StubTimeSlotAdapter implements TimeSlotPort {
 
     @Override
-    public void decrementStock(UUID timeSlotId, int requiredCapacity) {
-        log.debug("[STUB] decrementStock skipped — timeSlotId={}, requiredCapacity={}", timeSlotId, requiredCapacity);
+    public void decrementStock(UUID timeSlotId, int requiredCapacity, UUID reservationId) {
+        log.debug("[STUB] decrementStock skipped — timeSlotId={}, requiredCapacity={}, reservationId={}",
+                timeSlotId, requiredCapacity, reservationId);
     }
 
     @Override

--- a/src/main/java/com/michelet/reservation/infrastructure/client/adapter/TimeSlotAdapter.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/client/adapter/TimeSlotAdapter.java
@@ -22,7 +22,7 @@ public class TimeSlotAdapter implements TimeSlotPort {
 
     @Override
     public void decrementStock(UUID timeSlotId, int requiredCapacity, UUID reservationId) {
-        String idempotencyKey = "reservation:" + reservationId;
+        String idempotencyKey = "deduct:" + timeSlotId + ":" + reservationId;
         try {
             timeSlotClient.decrementStock(
                     timeSlotId, idempotencyKey, new TimeSlotDeductCapacityRequest(requiredCapacity));
@@ -32,10 +32,16 @@ public class TimeSlotAdapter implements TimeSlotPort {
                     timeSlotId, reservationId, e.getMessage());
             throw new ExternalCallFailedException("timeslot-service 연결 불안정", e);
         } catch (FeignException e) {
-            if (e.status() >= 400 && e.status() < 500) {
-                // 비즈니스 거부 (슬롯 부족, 슬롯 없음 등) — 차감 미처리 확정 → 롤백
-                log.warn("[timeslot] 슬롯 차감 거부 (4xx) — timeSlotId={}, status={}", timeSlotId, e.status());
+            if (e.status() == 409) {
+                // 명시적 비즈니스 거부(잔여 좌석 부족) — 차감 미처리 확정 → 롤백
+                log.warn("[timeslot] 슬롯 차감 거부 (409) — timeSlotId={}, reservationId={}", timeSlotId, reservationId);
                 throw new BusinessException(ReservationErrorCode.SLOT_NOT_AVAILABLE);
+            }
+            if (e.status() >= 400 && e.status() < 500) {
+                // 인증·인가·요청 오류 등 — 비즈니스 거부로 단정하지 않음 → 호출자가 503 처리
+                log.error("[timeslot] 클라이언트 오류 — timeSlotId={}, reservationId={}, status={}",
+                        timeSlotId, reservationId, e.status(), e);
+                throw new ExternalCallFailedException("timeslot-service 클라이언트 오류", e);
             }
             // 5xx 서버 오류 — 처리 여부 불확실 → 호출자가 WAITING 처리
             log.error("[timeslot] 서버 오류 — timeSlotId={}, reservationId={}, status={}",

--- a/src/main/java/com/michelet/reservation/infrastructure/client/adapter/TimeSlotAdapter.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/client/adapter/TimeSlotAdapter.java
@@ -1,8 +1,13 @@
 package com.michelet.reservation.infrastructure.client.adapter;
 
+import com.michelet.common.exception.BusinessException;
+import com.michelet.reservation.application.exception.ExternalCallFailedException;
 import com.michelet.reservation.application.port.TimeSlotPort;
+import com.michelet.reservation.domain.exception.ReservationErrorCode;
 import com.michelet.reservation.infrastructure.client.TimeSlotClient;
 import com.michelet.reservation.infrastructure.client.dto.TimeSlotDeductCapacityRequest;
+import feign.FeignException;
+import feign.RetryableException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,13 +21,33 @@ public class TimeSlotAdapter implements TimeSlotPort {
     private final TimeSlotClient timeSlotClient;
 
     @Override
-    public void decrementStock(UUID timeSlotId, int requiredCapacity) {
-        timeSlotClient.decrementStock(timeSlotId, new TimeSlotDeductCapacityRequest(requiredCapacity));
+    public void decrementStock(UUID timeSlotId, int requiredCapacity, UUID reservationId) {
+        String idempotencyKey = "reservation:" + reservationId;
+        try {
+            timeSlotClient.decrementStock(
+                    timeSlotId, idempotencyKey, new TimeSlotDeductCapacityRequest(requiredCapacity));
+        } catch (RetryableException e) {
+            // 타임아웃 또는 네트워크 단절 — 처리 여부 불확실 → 호출자가 WAITING 처리
+            log.warn("[timeslot] 네트워크 오류 — timeSlotId={}, reservationId={}: {}",
+                    timeSlotId, reservationId, e.getMessage());
+            throw new ExternalCallFailedException("timeslot-service 연결 불안정", e);
+        } catch (FeignException e) {
+            if (e.status() >= 400 && e.status() < 500) {
+                // 비즈니스 거부 (슬롯 부족, 슬롯 없음 등) — 차감 미처리 확정 → 롤백
+                log.warn("[timeslot] 슬롯 차감 거부 (4xx) — timeSlotId={}, status={}", timeSlotId, e.status());
+                throw new BusinessException(ReservationErrorCode.SLOT_NOT_AVAILABLE);
+            }
+            // 5xx 서버 오류 — 처리 여부 불확실 → 호출자가 WAITING 처리
+            log.error("[timeslot] 서버 오류 — timeSlotId={}, reservationId={}, status={}",
+                    timeSlotId, reservationId, e.status(), e);
+            throw new ExternalCallFailedException("timeslot-service 서버 오류", e);
+        }
     }
 
     @Override
     public void incrementStock(UUID timeSlotId, int requiredCapacity) {
         // TODO: timeslot-service restore API 미구현 — 구현 시 차감과 동일하게 POST /deduct 역방향 or 별도 엔드포인트 호출
-        log.warn("incrementStock skipped — timeslot-service restore API not yet implemented. timeSlotId={}, requiredCapacity={}", timeSlotId, requiredCapacity);
+        log.warn("incrementStock skipped — timeslot-service restore API not yet implemented. timeSlotId={}, requiredCapacity={}",
+                timeSlotId, requiredCapacity);
     }
 }

--- a/src/main/java/com/michelet/reservation/infrastructure/config/FeignTimeSlotConfig.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/config/FeignTimeSlotConfig.java
@@ -4,10 +4,8 @@ import feign.Retryer;
 import org.springframework.context.annotation.Bean;
 
 /**
- * timeslot-service Feign 클라이언트 전용 설정.
- * Spring Cloud OpenFeign 기본값(NEVER_RETRY)과 동일하지만, 이중 차감 방지 의도를 코드로 명시한다.
- *
- * 주의: @Configuration 없이 @FeignClient(configuration = ...) 로만 등록 — 전역 빈 충돌 방지
+ * timeslot-service Feign 클라이언트 전용 설정. Spring Cloud OpenFeign 기본값(NEVER_RETRY)과 동일하지만, 이중 차감 방지 의도를 코드로 명시한다. 주의:
+ * @Configuration 없이 @FeignClient(configuration = ...) 로만 등록 — 전역 빈 충돌 방지
  */
 public class FeignTimeSlotConfig {
 

--- a/src/main/java/com/michelet/reservation/infrastructure/config/FeignTimeSlotConfig.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/config/FeignTimeSlotConfig.java
@@ -1,0 +1,19 @@
+package com.michelet.reservation.infrastructure.config;
+
+import feign.Retryer;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * timeslot-service Feign 클라이언트 전용 설정.
+ * Spring Cloud OpenFeign 기본값(NEVER_RETRY)과 동일하지만, 이중 차감 방지 의도를 코드로 명시한다.
+ *
+ * 주의: @Configuration 없이 @FeignClient(configuration = ...) 로만 등록 — 전역 빈 충돌 방지
+ */
+public class FeignTimeSlotConfig {
+
+    @Bean
+    public Retryer timeslotServiceRetryer() {
+        // 재시도 시 슬롯 이중 차감 위험 → 절대 재시도 없음
+        return Retryer.NEVER_RETRY;
+    }
+}

--- a/src/main/java/com/michelet/reservation/presentation/ReservationExceptionHandler.java
+++ b/src/main/java/com/michelet/reservation/presentation/ReservationExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.michelet.reservation.presentation;
 
 import com.michelet.common.response.ApiResponse;
+import com.michelet.reservation.application.exception.ExternalCallFailedException;
 import com.michelet.reservation.domain.exception.ReservationErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
@@ -22,6 +23,20 @@ public class ReservationExceptionHandler {
         return ApiResponse.fail(
                 ReservationErrorCode.CONCURRENT_UPDATE_CONFLICT.getCode(),
                 ReservationErrorCode.CONCURRENT_UPDATE_CONFLICT.getMessage()
+        );
+    }
+
+    /**
+     * modify() 등에서 timeslot-service 연결 실패 시 → 503
+     * create()는 서비스 내에서 catch하여 WAITING 반환하므로 이 핸들러에 도달하지 않는다.
+     */
+    @ExceptionHandler(ExternalCallFailedException.class)
+    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    public ApiResponse<Void> handleExternalCallFailed(ExternalCallFailedException e) {
+        log.error("[external] 외부 서비스 연결 실패 — 일시적 장애: {}", e.getMessage());
+        return ApiResponse.fail(
+                ReservationErrorCode.TIMESLOT_SERVICE_UNAVAILABLE.getCode(),
+                ReservationErrorCode.TIMESLOT_SERVICE_UNAVAILABLE.getMessage()
         );
     }
 }

--- a/src/main/java/com/michelet/reservation/presentation/ReservationExceptionHandler.java
+++ b/src/main/java/com/michelet/reservation/presentation/ReservationExceptionHandler.java
@@ -26,14 +26,11 @@ public class ReservationExceptionHandler {
         );
     }
 
-    /**
-     * modify() 등에서 timeslot-service 연결 실패 시 → 503
-     * create()는 서비스 내에서 catch하여 WAITING 반환하므로 이 핸들러에 도달하지 않는다.
-     */
+    /** 외부 연동 실패 예외가 컨트롤러 계층까지 전파된 경우 503(Service Unavailable)을 반환한다. */
     @ExceptionHandler(ExternalCallFailedException.class)
     @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
     public ApiResponse<Void> handleExternalCallFailed(ExternalCallFailedException e) {
-        log.error("[external] 외부 서비스 연결 실패 — 일시적 장애: {}", e.getMessage());
+        log.error("[external] 외부 서비스 연결 실패 — 일시적 장애: {}", e.getMessage(), e);
         return ApiResponse.fail(
                 ReservationErrorCode.TIMESLOT_SERVICE_UNAVAILABLE.getCode(),
                 ReservationErrorCode.TIMESLOT_SERVICE_UNAVAILABLE.getMessage()

--- a/src/test/java/com/michelet/reservation/application/reservation/ReservationCommandServiceTest.java
+++ b/src/test/java/com/michelet/reservation/application/reservation/ReservationCommandServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -14,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 import com.michelet.common.exception.BusinessException;
 import com.michelet.reservation.application.event.ReservationCreatedAppEvent;
+import com.michelet.reservation.application.exception.ExternalCallFailedException;
 import com.michelet.reservation.application.port.TimeSlotPort;
 import com.michelet.reservation.application.port.WaitingPort;
 import com.michelet.reservation.application.port.WaitingTokenResult;
@@ -136,8 +138,9 @@ class ReservationCommandServiceTest {
             ReservationResult result = commandService.create(createCommand());
 
             assertThat(result).isNotNull();
+            assertThat(result.status()).isEqualTo(ReservationStatus.CONFIRMED);
             verify(reservationRepository, times(2)).save(any(Reservation.class));
-            verify(timeSlotPort).decrementStock(eq(timeSlotId), eq(2));
+            verify(timeSlotPort).decrementStock(eq(timeSlotId), eq(2), any(UUID.class));
             verify(waitingPort).completeWaiting(eq(waitingId));
             verify(eventPublisher).publishEvent(any(ReservationCreatedAppEvent.class));
         }
@@ -163,6 +166,62 @@ class ReservationCommandServiceTest {
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ReservationErrorCode.DUPLICATE_RESERVATION.getCode()));
         }
+
+        @Test
+        void 슬롯_차감_타임아웃_시_예약이_WAITING_상태로_저장된다() {
+            doThrow(new ExternalCallFailedException("read timeout", new RuntimeException()))
+                    .when(timeSlotPort).decrementStock(any(), anyInt(), any());
+
+            ReservationResult result = commandService.create(createCommand());
+
+            assertThat(result.status()).isEqualTo(ReservationStatus.WAITING);
+            // WAITING save 1회만 — CONFIRMED 전환 save 없음
+            verify(reservationRepository, times(1)).save(any(Reservation.class));
+            verify(waitingPort, never()).completeWaiting(any());
+            verify(eventPublisher, never()).publishEvent(any());
+        }
+
+        @Test
+        void 슬롯_차감_네트워크_오류_시_예약이_WAITING_상태로_저장된다() {
+            doThrow(new ExternalCallFailedException("connection refused", new RuntimeException()))
+                    .when(timeSlotPort).decrementStock(any(), anyInt(), any());
+
+            ReservationResult result = commandService.create(createCommand());
+
+            assertThat(result.status()).isEqualTo(ReservationStatus.WAITING);
+            verify(reservationRepository, times(1)).save(any(Reservation.class));
+            verify(waitingPort, never()).completeWaiting(any());
+        }
+
+        @Test
+        void 슬롯_부족으로_차감_거부_시_BusinessException이_발생한다() {
+            // timeslot-service 4xx 응답 → adapter가 BusinessException으로 변환
+            doThrow(new BusinessException(ReservationErrorCode.SLOT_NOT_AVAILABLE))
+                    .when(timeSlotPort).decrementStock(any(), anyInt(), any());
+
+            assertThatThrownBy(() -> commandService.create(createCommand()))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ReservationErrorCode.SLOT_NOT_AVAILABLE.getCode()));
+
+            // BusinessException 전파 → 트랜잭션 롤백 (WAITING save도 취소됨)
+            // 실제 롤백 검증은 통합 테스트에서 확인
+            verify(waitingPort, never()).completeWaiting(any());
+            verify(eventPublisher, never()).publishEvent(any());
+        }
+
+        @Test
+        void 대기열_완료_실패_시에도_예약이_CONFIRMED_상태로_저장된다() {
+            // 슬롯 차감 성공 이후 waitingPort 실패 → 예약은 정상 확정
+            doThrow(new RuntimeException("waiting-service unavailable"))
+                    .when(waitingPort).completeWaiting(any());
+
+            ReservationResult result = commandService.create(createCommand());
+
+            assertThat(result.status()).isEqualTo(ReservationStatus.CONFIRMED);
+            verify(reservationRepository, times(2)).save(any(Reservation.class));
+            verify(eventPublisher).publishEvent(any(ReservationCreatedAppEvent.class));
+        }
     }
 
     @Nested
@@ -180,7 +239,7 @@ class ReservationCommandServiceTest {
             ));
 
             verify(timeSlotPort).incrementStock(timeSlotId, 2);
-            verify(timeSlotPort).decrementStock(timeSlotId, 2);
+            verify(timeSlotPort).decrementStock(eq(timeSlotId), eq(2), any(UUID.class));
         }
 
         @Test
@@ -197,7 +256,7 @@ class ReservationCommandServiceTest {
             ));
 
             verify(timeSlotPort).incrementStock(timeSlotId, 2);
-            verify(timeSlotPort).decrementStock(newSlotId, 2);
+            verify(timeSlotPort).decrementStock(eq(newSlotId), eq(2), any(UUID.class));
         }
 
         @Test
@@ -225,7 +284,7 @@ class ReservationCommandServiceTest {
             ));
 
             verify(timeSlotPort, never()).incrementStock(any(), anyInt());
-            verify(timeSlotPort, never()).decrementStock(any(), anyInt());
+            verify(timeSlotPort, never()).decrementStock(any(), anyInt(), any());
         }
 
         @Test

--- a/src/test/java/com/michelet/reservation/infrastructure/config/FeignTimeSlotConfigTest.java
+++ b/src/test/java/com/michelet/reservation/infrastructure/config/FeignTimeSlotConfigTest.java
@@ -1,0 +1,15 @@
+package com.michelet.reservation.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import feign.Retryer;
+import org.junit.jupiter.api.Test;
+
+class FeignTimeSlotConfigTest {
+
+    @Test
+    void timeslot_service_retryer가_NEVER_RETRY로_설정된다() {
+        FeignTimeSlotConfig config = new FeignTimeSlotConfig();
+        assertThat(config.timeslotServiceRetryer()).isSameAs(Retryer.NEVER_RETRY);
+    }
+}


### PR DESCRIPTION
…n process

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- fegin 호출 신뢰성 문제 임시 해결

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #38   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.
<img width="2306" height="310" alt="image" src="https://github.com/user-attachments/assets/4fdcb956-8b58-49e2-bd79-94527adb3b74" />
<img width="1306" height="604" alt="image" src="https://github.com/user-attachments/assets/051728d0-9334-44f0-bcbb-728689b0acb5" />

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [x] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 외부 호출 실패를 나타내는 전용 예외 추가로 실패 유형을 명확히 처리
  * 외부 재시도 방지 및 요청별 idempotency 키 도입으로 중복 차감 방지
  * 외부 호출 실패 시 503 응답 매핑 및 예약 대기 처리 흐름 반영

* **Bug Fixes**
  * 슬롯 차감/복구 관련 외부 오류 매핑 및 예외 처리 개선
  * 예약 생성/수정 시 네트워크·타임아웃 실패 대응 강化

* **Tests**
  * 외부 서비스 장애 및 idempotency 관련 시나리오 테스트 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/reservation-service/pull/39)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->