### PR TITLE
[Feat] noshow 스케쥴러

### DIFF
--- a/http/reservation.http
+++ b/http/reservation.http
@@ -411,6 +411,37 @@ X-User-Role: USER
 
 ###
 
+### [NoShow] 9. No-Show 자동 전이 수동 검증
+# [목적]   noshowDeadline이 지난 CONFIRMED 예약이 스케줄러에 의해 NO_SHOW로 전이되는지 확인
+# [전제]   1번 예약이 CONFIRMED 상태로 존재해야 함 (체크인하지 않은 상태)
+#
+# [Step 1] DB에서 noshow_deadline을 현재 시각 기준 과거로 수동 조작
+#   -- psql 또는 DataGrip 등에서 실행:
+#   UPDATE reservation_service.p_reservations
+#   SET noshow_deadline = NOW() - INTERVAL '1 minute'
+#   WHERE id = '<reservation_id>'
+#     AND status = 'CONFIRMED';
+#
+# [Step 2] 스케줄러가 실행될 때까지 최대 60초 대기 (noshow.scheduler.fixed-delay-ms=60000)
+#
+# [Step 3] 아래 요청으로 상태 변경 확인 (status=NO_SHOW 기대)
+GET {{base_url}}/api/v1/reservations/{{reservation_id}}
+X-User-Id: {{user_id}}
+X-User-Role: USER
+
+> {%
+    client.test("200 OK", function () {
+        client.assert(response.status === 200, "Expected 200, got " + response.status);
+    });
+    client.test("status NO_SHOW (스케줄러 전이 완료)", function () {
+        client.assert(response.body.data.status === "NO_SHOW",
+            "Expected status=NO_SHOW, got " + response.body.data.status +
+            " (스케줄러 주기 60초 대기 후 재시도)");
+    });
+%}
+
+###
+
 ### [에러 케이스] 취소 기한 초과 예약 삭제 시도
 # [플로우] 취소 기한이 지난 CONFIRMED 예약을 soft-delete → 슬롯 재고 반환 없이 삭제
 # [데이터] reservation_id (체크인 완료된 예약이면 COMPLETED 상태로도 삭제 가능)

--- a/src/main/java/com/michelet/reservation/infrastructure/kafka/KafkaTopics.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/kafka/KafkaTopics.java
@@ -12,6 +12,8 @@ public final class KafkaTopics {
     public static final String RESERVATION_MODIFICATION_VOIDED = "reservation.modification.voided";
     public static final String RESERVATION_SLOT_RELEASED       = "reservation.slot.released";
 
+    public static final String RESERVATION_NO_SHOW = "reservation.no-show";
+
     public static final String SLOT_DEDUCTED    = "slot.deducted";
     public static final String SLOT_UNAVAILABLE = "slot.unavailable";
 

--- a/src/main/java/com/michelet/reservation/infrastructure/kafka/dedup/ConsumedEventTracker.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/kafka/dedup/ConsumedEventTracker.java
@@ -14,11 +14,6 @@ public class ConsumedEventTracker {
     private static final Duration TTL = Duration.ofHours(48);
     private final StringRedisTemplate redisTemplate;
 
-    /**
-     * 이 eventId를 처음 보는 경우 true를 반환하고 처리됨으로 표시한다.
-     * 이미 처리된 eventId라면 false를 반환한다.
-     * Redis SET NX로 원자적으로 처리하므로 다중 인스턴스 환경에서도 안전하다.
-     */
     public boolean tryMarkAsNew(String eventId) {
         if (eventId == null || eventId.isBlank()) {
             log.warn("[dedup] eventId가 null 또는 빈 값입니다 — dedup 없이 처리 불가로 판단");

--- a/src/main/java/com/michelet/reservation/infrastructure/kafka/event/publish/ReservationNoShowEvent.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/kafka/event/publish/ReservationNoShowEvent.java
@@ -1,0 +1,16 @@
+package com.michelet.reservation.infrastructure.kafka.event.publish;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ReservationNoShowEvent(
+        UUID eventId,
+        UUID reservationId,
+        UUID userId,
+        UUID restaurantId,
+        UUID timeSlotId,
+        LocalDate reservedDate,
+        int guestCount,
+        LocalDateTime occurredAt
+) {}

--- a/src/main/java/com/michelet/reservation/infrastructure/noshow/NoShowScheduler.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/noshow/NoShowScheduler.java
@@ -1,0 +1,99 @@
+package com.michelet.reservation.infrastructure.noshow;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.michelet.reservation.domain.entity.Reservation;
+import com.michelet.reservation.infrastructure.kafka.KafkaTopics;
+import com.michelet.reservation.infrastructure.kafka.event.publish.ReservationNoShowEvent;
+import com.michelet.reservation.infrastructure.outbox.AggregateType;
+import com.michelet.reservation.infrastructure.outbox.OutboxEventJpaRepository;
+import com.michelet.reservation.infrastructure.outbox.entity.OutboxEventJpaEntity;
+import com.michelet.reservation.infrastructure.reservation.ReservationJpaStore;
+import com.michelet.reservation.infrastructure.reservation.entity.ReservationJpaEntity;
+import com.michelet.reservation.infrastructure.reservation.mapper.ReservationMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "kafka.stub", havingValue = "false", matchIfMissing = true)
+public class NoShowScheduler {
+
+    private static final int BATCH_SIZE = 50;
+
+    private final ReservationJpaStore jpaStore;
+    private final OutboxEventJpaRepository outboxEventJpaRepository;
+    private final ObjectMapper objectMapper;
+    private final TransactionTemplate transactionTemplate;
+
+    public NoShowScheduler(
+            ReservationJpaStore jpaStore,
+            OutboxEventJpaRepository outboxEventJpaRepository,
+            ObjectMapper objectMapper,
+            TransactionTemplate transactionTemplate
+    ) {
+        this.jpaStore = jpaStore;
+        this.outboxEventJpaRepository = outboxEventJpaRepository;
+        this.objectMapper = objectMapper;
+        this.transactionTemplate = transactionTemplate;
+    }
+
+    @Scheduled(fixedDelayString = "${noshow.scheduler.fixed-delay-ms:60000}")
+    public void markExpiredReservationsAsNoShow() {
+        // TX-1: 짧은 읽기 트랜잭션 — 만료된 CONFIRMED 예약 배치 조회 후 즉시 커밋
+        List<ReservationJpaEntity> candidates = transactionTemplate.execute(
+                tx -> jpaStore.findExpiredConfirmedForUpdate(LocalDateTime.now(), BATCH_SIZE)
+        );
+        if (candidates == null || candidates.isEmpty()) {
+            return;
+        }
+
+        for (ReservationJpaEntity candidate : candidates) {
+            try {
+                // TX-2: 건당 쓰기 트랜잭션 — 상태 재검증 후 NO_SHOW 전이 + 아웃박스 저장
+                transactionTemplate.execute(tx -> {
+                    Optional<ReservationJpaEntity> managedOpt =
+                            jpaStore.findByIdAndStatusConfirmedForUpdate(candidate.getId());
+                    if (managedOpt.isEmpty()) {
+                        // TX-1과 TX-2 사이에 체크인 또는 취소가 완료된 경우
+                        return null;
+                    }
+
+                    ReservationJpaEntity managed = managedOpt.get();
+                    Reservation domain = ReservationMapper.toDomain(managed);
+                    domain.markNoShow();
+                    managed.applyFrom(domain);
+                    jpaStore.save(managed);
+
+                    LocalDateTime now = LocalDateTime.now();
+                    ReservationNoShowEvent event = new ReservationNoShowEvent(
+                            UUID.randomUUID(), managed.getId(), managed.getUserId(),
+                            managed.getRestaurantId(), managed.getTimeSlotId(),
+                            managed.getReservedDate(), managed.getGuestCount(), now
+                    );
+                    try {
+                        String json = objectMapper.writeValueAsString(event);
+                        outboxEventJpaRepository.save(
+                                OutboxEventJpaEntity.create(managed.getId(),
+                                        AggregateType.RESERVATION, KafkaTopics.RESERVATION_NO_SHOW, json)
+                        );
+                    } catch (JsonProcessingException e) {
+                        throw new IllegalStateException("NoShow 이벤트 직렬화 실패 — reservationId=" + managed.getId(), e);
+                    }
+
+                    log.info("[NoShow] 처리 완료 — reservationId={}", managed.getId());
+                    return null;
+                });
+            } catch (Exception e) {
+                log.error("[NoShow] 처리 실패 — id={}", candidate.getId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/michelet/reservation/infrastructure/reservation/ReservationJpaStore.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/reservation/ReservationJpaStore.java
@@ -3,6 +3,7 @@ package com.michelet.reservation.infrastructure.reservation;
 import com.michelet.reservation.domain.enums.ReservationStatus;
 import com.michelet.reservation.infrastructure.reservation.entity.ReservationJpaEntity;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -10,6 +11,8 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReservationJpaStore extends JpaRepository<ReservationJpaEntity, UUID> {
 
@@ -25,4 +28,27 @@ public interface ReservationJpaStore extends JpaRepository<ReservationJpaEntity,
     Optional<ReservationJpaEntity> findTopByUserIdAndRestaurantIdAndStatusInOrderByReservedDateDesc(UUID userId, UUID restaurantId, List<ReservationStatus> statuses);
 
     boolean existsByUserIdAndStatus(UUID userId, ReservationStatus status);
+
+    @Query(value = """
+            SELECT * FROM reservation_service.p_reservations
+            WHERE status = 'CONFIRMED'
+              AND noshow_deadline <= :now
+              AND deleted_at IS NULL
+            ORDER BY noshow_deadline
+            LIMIT :limit
+            FOR UPDATE SKIP LOCKED
+            """, nativeQuery = true)
+    List<ReservationJpaEntity> findExpiredConfirmedForUpdate(
+            @Param("now") LocalDateTime now,
+            @Param("limit") int limit
+    );
+
+    @Query(value = """
+            SELECT * FROM reservation_service.p_reservations
+            WHERE id = :id
+              AND status = 'CONFIRMED'
+              AND deleted_at IS NULL
+            FOR UPDATE SKIP LOCKED
+            """, nativeQuery = true)
+    Optional<ReservationJpaEntity> findByIdAndStatusConfirmedForUpdate(@Param("id") UUID id);
 }

--- a/src/main/java/com/michelet/reservation/presentation/reservation/ReservationController.java
+++ b/src/main/java/com/michelet/reservation/presentation/reservation/ReservationController.java
@@ -61,8 +61,10 @@ public class ReservationController {
       @RequestBody @Valid CreateReservationRequest request
   ) {
     UUID userId = currentUserId();
-    if (idempotencyKey != null) {
-      String scopedKey = "reservation:create:" + userId + ":" + idempotencyKey;
+    String scopedKey = (idempotencyKey != null && !idempotencyKey.isBlank())
+        ? "reservation:create:" + userId + ":" + idempotencyKey
+        : null;
+    if (scopedKey != null) {
       var cached = idempotencyService.findCachedResponse(scopedKey);
       if (cached.isPresent()) {
         try {
@@ -85,8 +87,7 @@ public class ReservationController {
         ))
     );
 
-    if (idempotencyKey != null) {
-      String scopedKey = "reservation:create:" + userId + ":" + idempotencyKey;
+    if (scopedKey != null) {
       try {
         idempotencyService.cacheResponse(scopedKey, objectMapper.writeValueAsString(response));
       } catch (JsonProcessingException e) {
@@ -133,8 +134,10 @@ public class ReservationController {
       @RequestBody @Valid ModifyReservationRequest request
   ) {
     UUID userId = currentUserId();
-    if (idempotencyKey != null) {
-      String scopedKey = "reservation:modify:" + reservationId + ":" + userId + ":" + idempotencyKey;
+    String scopedKey = (idempotencyKey != null && !idempotencyKey.isBlank())
+        ? "reservation:modify:" + reservationId + ":" + userId + ":" + idempotencyKey
+        : null;
+    if (scopedKey != null) {
       var cached = idempotencyService.findCachedResponse(scopedKey);
       if (cached.isPresent()) {
         try {
@@ -158,8 +161,7 @@ public class ReservationController {
         ))
     );
 
-    if (idempotencyKey != null) {
-      String scopedKey = "reservation:modify:" + reservationId + ":" + userId + ":" + idempotencyKey;
+    if (scopedKey != null) {
       try {
         idempotencyService.cacheResponse(scopedKey, objectMapper.writeValueAsString(response));
       } catch (JsonProcessingException e) {

--- a/src/test/java/com/michelet/reservation/infrastructure/kafka/dedup/ConsumedEventTrackerTest.java
+++ b/src/test/java/com/michelet/reservation/infrastructure/kafka/dedup/ConsumedEventTrackerTest.java
@@ -1,0 +1,64 @@
+package com.michelet.reservation.infrastructure.kafka.dedup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+class ConsumedEventTrackerTest {
+
+    @Mock StringRedisTemplate redisTemplate;
+    @Mock ValueOperations<String, String> valueOps;
+    @InjectMocks ConsumedEventTracker tracker;
+
+    @Test
+    void null_eventId는_false를_반환하고_Redis를_호출하지_않는다() {
+        assertThat(tracker.tryMarkAsNew(null)).isFalse();
+        verify(redisTemplate, never()).opsForValue();
+    }
+
+    @Test
+    void 빈_eventId는_false를_반환하고_Redis를_호출하지_않는다() {
+        assertThat(tracker.tryMarkAsNew("  ")).isFalse();
+        verify(redisTemplate, never()).opsForValue();
+    }
+
+    @Test
+    void 새로운_eventId는_Redis에_등록하고_true를_반환한다() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(valueOps.setIfAbsent(anyString(), anyString(), any(Duration.class))).thenReturn(true);
+
+        assertThat(tracker.tryMarkAsNew("event-abc")).isTrue();
+        verify(valueOps).setIfAbsent(
+                eq("consumed-event:event-abc"), eq("1"), eq(Duration.ofHours(48)));
+    }
+
+    @Test
+    void 중복_eventId는_false를_반환한다() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(valueOps.setIfAbsent(anyString(), anyString(), any(Duration.class))).thenReturn(false);
+
+        assertThat(tracker.tryMarkAsNew("event-abc")).isFalse();
+    }
+
+    @Test
+    void Redis_장애로_null_반환_시_false를_반환한다() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(valueOps.setIfAbsent(anyString(), anyString(), any(Duration.class))).thenReturn(null);
+
+        assertThat(tracker.tryMarkAsNew("event-abc")).isFalse();
+    }
+}

--- a/src/test/java/com/michelet/reservation/infrastructure/noshow/NoShowSchedulerTest.java
+++ b/src/test/java/com/michelet/reservation/infrastructure/noshow/NoShowSchedulerTest.java
@@ -1,0 +1,100 @@
+package com.michelet.reservation.infrastructure.noshow;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.michelet.reservation.domain.enums.ReservationStatus;
+import com.michelet.reservation.infrastructure.outbox.OutboxEventJpaRepository;
+import com.michelet.reservation.infrastructure.reservation.ReservationJpaStore;
+import com.michelet.reservation.infrastructure.reservation.entity.ReservationJpaEntity;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class NoShowSchedulerTest {
+
+    @Mock ReservationJpaStore jpaStore;
+    @Mock OutboxEventJpaRepository outboxEventJpaRepository;
+    @Mock TransactionTemplate transactionTemplate;
+
+    ObjectMapper objectMapper;
+    NoShowScheduler scheduler;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        scheduler = new NoShowScheduler(jpaStore, outboxEventJpaRepository, objectMapper, transactionTemplate);
+        doAnswer(inv -> ((TransactionCallback<Object>) inv.getArgument(0)).doInTransaction(null))
+                .when(transactionTemplate).execute(any());
+    }
+
+    ReservationJpaEntity confirmedEntity() {
+        return ReservationJpaEntity.of(
+                UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
+                LocalDate.now(), 2, ReservationStatus.CONFIRMED,
+                LocalDate.now().minusDays(2), LocalDate.now().minusDays(2),
+                LocalDateTime.now().minusMinutes(5), null
+        );
+    }
+
+    @Nested
+    class EmptyBatch {
+
+        @Test
+        void 만료된_예약이_없으면_아무것도_실행하지_않는다() {
+            when(jpaStore.findExpiredConfirmedForUpdate(any(), anyInt())).thenReturn(List.of());
+
+            scheduler.markExpiredReservationsAsNoShow();
+
+            verify(jpaStore, never()).findByIdAndStatusConfirmedForUpdate(any());
+            verify(outboxEventJpaRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    class NoShowTransition {
+
+        @Test
+        void 만료된_CONFIRMED_예약을_NO_SHOW로_전이하고_아웃박스를_저장한다() {
+            ReservationJpaEntity entity = confirmedEntity();
+            when(jpaStore.findExpiredConfirmedForUpdate(any(), anyInt())).thenReturn(List.of(entity));
+            when(jpaStore.findByIdAndStatusConfirmedForUpdate(entity.getId())).thenReturn(Optional.of(entity));
+            when(jpaStore.save(any())).thenReturn(entity);
+
+            scheduler.markExpiredReservationsAsNoShow();
+
+            verify(outboxEventJpaRepository).save(argThat(e ->
+                    "reservation.no-show".equals(e.getEventType())));
+        }
+
+        @Test
+        void TX2에서_빈_결과_반환_시_이미_처리된_것으로_간주하고_아웃박스를_저장하지_않는다() {
+            ReservationJpaEntity entity = confirmedEntity();
+            when(jpaStore.findExpiredConfirmedForUpdate(any(), anyInt())).thenReturn(List.of(entity));
+            when(jpaStore.findByIdAndStatusConfirmedForUpdate(entity.getId())).thenReturn(Optional.empty());
+
+            scheduler.markExpiredReservationsAsNoShow();
+
+            verify(outboxEventJpaRepository, never()).save(any());
+        }
+    }
+}

--- a/src/test/java/com/michelet/reservation/presentation/reservation/ReservationControllerTest.java
+++ b/src/test/java/com/michelet/reservation/presentation/reservation/ReservationControllerTest.java
@@ -3,6 +3,8 @@ package com.michelet.reservation.presentation.reservation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -22,6 +24,7 @@ import com.michelet.reservation.application.reservation.ReservationCommandServic
 import com.michelet.reservation.application.reservation.ReservationQueryService;
 import com.michelet.reservation.application.reservation.result.ReservationResult;
 import com.michelet.reservation.application.reservation.result.ReservationSummaryResult;
+import com.michelet.reservation.presentation.reservation.dto.response.ReservationResponse;
 import com.michelet.reservation.domain.enums.ReservationStatus;
 import com.michelet.reservation.domain.exception.ReservationErrorCode;
 import org.springframework.dao.OptimisticLockingFailureException;
@@ -147,6 +150,27 @@ class ReservationControllerTest {
         }
 
         @Test
+        void Idempotency_Key_캐시_히트_시_create를_호출하지_않고_캐시된_응답을_반환한다() throws Exception {
+            String idempotencyKey = "test-idem-key";
+            String scopedKey = "reservation:create:" + userId + ":" + idempotencyKey;
+            ReservationResponse cached = ReservationResponse.from(reservationResult());
+            when(idempotencyService.findCachedResponse(scopedKey))
+                    .thenReturn(Optional.of(objectMapper.writeValueAsString(cached)));
+
+            mockMvc.perform(post("/api/v1/reservations")
+                            .header("X-User-Id", userId)
+                            .header("X-User-Role", "USER")
+                            .header("X-Waiting-Token", "valid-token")
+                            .header("Idempotency-Key", idempotencyKey)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validCreateRequest())))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.data.reservationId").value(reservationId.toString()));
+
+            verify(commandService, never()).create(any());
+        }
+
+        @Test
         void 대기열_토큰_유효하지_않으면_403을_반환한다() throws Exception {
             when(commandService.create(any()))
                     .thenThrow(new BusinessException(ReservationErrorCode.INVALID_WAITING_TOKEN));
@@ -259,6 +283,28 @@ class ReservationControllerTest {
                             .content(objectMapper.writeValueAsString(req)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.reservationId").value(reservationId.toString()));
+        }
+
+        @Test
+        void Idempotency_Key_캐시_히트_시_modify를_호출하지_않고_캐시된_응답을_반환한다() throws Exception {
+            String idempotencyKey = "test-idem-key";
+            String scopedKey = "reservation:modify:" + reservationId + ":" + userId + ":" + idempotencyKey;
+            ReservationResponse cached = ReservationResponse.from(reservationResult());
+            when(idempotencyService.findCachedResponse(scopedKey))
+                    .thenReturn(Optional.of(objectMapper.writeValueAsString(cached)));
+
+            ModifyReservationRequest req = new ModifyReservationRequest(null, null, null, null, null);
+
+            mockMvc.perform(patch("/api/v1/reservations/{id}", reservationId)
+                            .header("X-User-Id", userId)
+                            .header("X-User-Role", "USER")
+                            .header("Idempotency-Key", idempotencyKey)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.reservationId").value(reservationId.toString()));
+
+            verify(commandService, never()).modify(any());
         }
 
         @Test


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- noshow 스케쥴러 개발
- 테스트 코드 일부 수정

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #  \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.
<img width="2440" height="330" alt="image" src="https://github.com/user-attachments/assets/73c9f77c-e03e-4e4b-a0cc-5c88c8b792e8" />
<img width="1154" height="720" alt="image" src="https://github.com/user-attachments/assets/2ceaaf10-5208-4121-b373-3a49729fda87" />

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 노쇼 데드라인이 지난 예약이 자동으로 NO_SHOW 상태로 전이되도록 개선했습니다.
  * 예약 생성 및 수정 요청의 중복 처리를 개선하여 캐시된 응답 반환 처리를 강화했습니다.

* **Tests**
  * 노쇼 자동 전이 및 이벤트 처리 검증 테스트를 추가했습니다.
  * 중복 요청 캐시 동작 검증 테스트를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/reservation-service/pull/54)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->