### PR TITLE
[Perf/Fix] 읽기 포화 임계점 해소 — Redis 캐싱 도입 및 안정성·보안 개선

### DIFF
--- a/k6/docker-compose.load-test.yml
+++ b/k6/docker-compose.load-test.yml
@@ -18,7 +18,7 @@ services:
       - "15432:5432"
     volumes:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql:ro
-      - lt-db-data:/var/lib/postgresql/data
+      - lt-db-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d michelet_db"]
       interval: 10s

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
@@ -30,6 +30,8 @@ import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -61,6 +63,8 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     // ── create ──────────────────────────────────────────────────────────────
 
     @Override
+    // 새 예약이 userId의 list에 추가되므로 list 캐시 전체 무효화
+    @CacheEvict(cacheNames = "reservation:list", allEntries = true)
     public ReservationResult create(CreateReservationCommand command) {
         // 1단계: 대기열 토큰 검증 (Feign 호출, DB 커넥션 미점유)
         var tokenResult = waitingPort.verifyToken(command.waitingToken());
@@ -125,6 +129,10 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     // ── modify ──────────────────────────────────────────────────────────────
 
     @Override
+    @Caching(evict = {
+            @CacheEvict(cacheNames = "reservation:list",   allEntries = true),
+            @CacheEvict(cacheNames = "reservation:detail", key = "#command.reservationId().toString()")
+    })
     public ReservationResult modify(ModifyReservationCommand command) {
         // 1단계: 델타 계산을 위한 현재 슬롯 상태 스냅샷 로드 (짧은 읽기 전용 TX, 즉시 커넥션 반환)
         SlotSnapshot snapshot = Objects.requireNonNull(
@@ -254,6 +262,10 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     // ── cancel ──────────────────────────────────────────────────────────────
 
     @Override
+    @Caching(evict = {
+            @CacheEvict(cacheNames = "reservation:list",   allEntries = true),
+            @CacheEvict(cacheNames = "reservation:detail", key = "#command.reservationId().toString()")
+    })
     public void cancel(CancelReservationCommand command) {
         // 1단계: DB 전용 트랜잭션
         SlotReturnInfo slotInfo = writeTx.execute(status -> cancelRecord(command));
@@ -279,6 +291,10 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     // ── delete ──────────────────────────────────────────────────────────────
 
     @Override
+    @Caching(evict = {
+            @CacheEvict(cacheNames = "reservation:list",   allEntries = true),
+            @CacheEvict(cacheNames = "reservation:detail", key = "#command.reservationId().toString()")
+    })
     public void delete(DeleteReservationCommand command) {
         // 1단계: DB 전용 트랜잭션
         SlotReturnInfo slotInfo = writeTx.execute(status -> deleteRecord(command));

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
@@ -63,7 +63,11 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     // ── create ──────────────────────────────────────────────────────────────
 
     @Override
-    // 새 예약이 userId의 list에 추가되므로 list 캐시 전체 무효화
+    // 새 예약이 userId의 list에 추가되므로 list 캐시 전체 무효화.
+    // @CacheEvict(beforeInvocation=false 기본값): 메서드 성공 반환 직후 실행.
+    // DB 커밋과 eviction 사이 짧은 레이스 윈도우에서 읽기 요청이 DB에서 fresh 데이터를 읽어
+    // 캐시를 갱신할 수 있으나, eviction이 이를 즉시 무효화하므로 stale 노출 없음.
+    // 실패한 쓰기에 대해서는 eviction이 실행되지 않아 기존 캐시가 보존된다.
     @CacheEvict(cacheNames = "reservation:list", allEntries = true)
     public ReservationResult create(CreateReservationCommand command) {
         // 1단계: 대기열 토큰 검증 (Feign 호출, DB 커넥션 미점유)
@@ -343,8 +347,9 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
             timeSlotPort.incrementStock(timeSlotId, guestCount,
                     "restore:" + timeSlotId + ":" + reservationId + ":" + operation);
         } catch (Exception e) {
-            log.warn("[RestoreSlot] 슬롯 복구 실패 — timeSlotId={}, reservationId={}, op={}",
+            log.warn("[RestoreSlot] 슬롯 복구 Feign 실패 — outbox 이벤트로 비동기 복구 예정 timeSlotId={}, reservationId={}, op={}",
                     timeSlotId, reservationId, operation, e);
+            outboxEventPort.recordSlotReleased(reservationId, timeSlotId, guestCount, LocalDateTime.now());
         }
     }
 

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationCommandServiceImpl.java
@@ -135,7 +135,7 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     @Override
     @Caching(evict = {
             @CacheEvict(cacheNames = "reservation:list",   allEntries = true),
-            @CacheEvict(cacheNames = "reservation:detail", key = "#command.reservationId().toString()")
+            @CacheEvict(cacheNames = "reservation:detail", key = "#command.userId().toString() + ':' + #command.reservationId().toString()")
     })
     public ReservationResult modify(ModifyReservationCommand command) {
         // 1단계: 델타 계산을 위한 현재 슬롯 상태 스냅샷 로드 (짧은 읽기 전용 TX, 즉시 커넥션 반환)
@@ -268,7 +268,7 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     @Override
     @Caching(evict = {
             @CacheEvict(cacheNames = "reservation:list",   allEntries = true),
-            @CacheEvict(cacheNames = "reservation:detail", key = "#command.reservationId().toString()")
+            @CacheEvict(cacheNames = "reservation:detail", key = "#command.userId().toString() + ':' + #command.reservationId().toString()")
     })
     public void cancel(CancelReservationCommand command) {
         // 1단계: DB 전용 트랜잭션
@@ -297,7 +297,7 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     @Override
     @Caching(evict = {
             @CacheEvict(cacheNames = "reservation:list",   allEntries = true),
-            @CacheEvict(cacheNames = "reservation:detail", key = "#command.reservationId().toString()")
+            @CacheEvict(cacheNames = "reservation:detail", key = "#command.userId().toString() + ':' + #command.reservationId().toString()")
     })
     public void delete(DeleteReservationCommand command) {
         // 1단계: DB 전용 트랜잭션

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationQueryServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationQueryServiceImpl.java
@@ -73,9 +73,12 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
 
     @Override
     @Transactional(readOnly = true)
+    // userId를 키에 포함 — 캐시 히트 시 verifyAccess()가 실행되지 않으므로
+    // 키 자체가 소유권을 보장해야 한다. userId 없이 reservationId만으로 캐싱하면
+    // 타 사용자가 UUID를 알 경우 캐시 히트로 무단 조회 가능.
     @Cacheable(
             cacheNames = "reservation:detail",
-            key = "#reservationId.toString()"
+            key = "#userId.toString() + ':' + #reservationId.toString()"
     )
     public ReservationResult getDetail(UUID userId, String userRole, UUID reservationId) {
         Reservation reservation = reservationRepository.findById(reservationId)

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationQueryServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationQueryServiceImpl.java
@@ -1,11 +1,10 @@
 package com.michelet.reservation.application.reservation;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.michelet.common.exception.BusinessException;
 import com.michelet.reservation.application.reservation.result.ReservationActiveResult;
 import com.michelet.reservation.application.reservation.result.ReservationCourseResult;
 import com.michelet.reservation.application.reservation.result.ReservationExistsResult;
+import com.michelet.reservation.application.reservation.result.ReservationListCachePage;
 import com.michelet.reservation.application.reservation.result.ReservationResult;
 import com.michelet.reservation.application.reservation.result.ReservationSummaryResult;
 import com.michelet.reservation.application.reservation.result.ReservationValidityResult;
@@ -39,17 +38,19 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
     //
     // getList()는 Page<T>를 직접 캐싱하지 않는다.
     // PageImpl에 @JsonCreator가 없어 GenericJackson2JsonRedisSerializer가 역직렬화에 실패하므로
-    // non-final 래퍼 클래스 CachedListPage에 content + totalElements만 저장하고
+    // non-final 래퍼 클래스 ReservationListCachePage에 content + totalElements만 저장하고
     // 캐시 히트 시 PageImpl로 재조립한다.
     @Override
     @Transactional(readOnly = true)
     public Page<ReservationSummaryResult> getList(UUID userId, ReservationStatus status, Pageable pageable) {
+        // sort 정보를 키에 포함 — 동일 page/size라도 정렬 기준이 다르면 별개 캐시 항목이어야 한다.
+        String sortKey = pageable.getSort().isSorted() ? pageable.getSort().toString() : "UNSORTED";
         String key = userId.toString() + ':' + (status != null ? status.name() : "ALL")
-                + ':' + pageable.getPageNumber() + ':' + pageable.getPageSize();
+                + ':' + pageable.getPageNumber() + ':' + pageable.getPageSize() + ':' + sortKey;
         Cache listCache = cacheManager.getCache("reservation:list");
 
         if (listCache != null) {
-            CachedListPage hit = listCache.get(key, CachedListPage.class);
+            ReservationListCachePage hit = listCache.get(key, ReservationListCachePage.class);
             if (hit != null) {
                 return new PageImpl<>(hit.content, pageable, hit.totalElements);
             }
@@ -64,7 +65,7 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
         long total = page.getTotalElements();
 
         if (listCache != null) {
-            listCache.put(key, new CachedListPage(content, total));
+            listCache.put(key, new ReservationListCachePage(content, total));
         }
 
         return new PageImpl<>(content, pageable, total);
@@ -130,18 +131,4 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
         }
     }
 
-    // Page<T>를 직접 캐싱하면 PageImpl 역직렬화 실패 → content + total만 저장하는 래퍼.
-    // non-final class(record 아님)이어야 NON_FINAL typing이 @class를 삽입한다.
-    static class CachedListPage {
-        public final List<ReservationSummaryResult> content;
-        public final long totalElements;
-
-        @JsonCreator
-        CachedListPage(
-                @JsonProperty("content") List<ReservationSummaryResult> content,
-                @JsonProperty("totalElements") long totalElements) {
-            this.content = content;
-            this.totalElements = totalElements;
-        }
-    }
 }

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationQueryServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package com.michelet.reservation.application.reservation;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.michelet.common.exception.BusinessException;
 import com.michelet.reservation.application.reservation.result.ReservationActiveResult;
 import com.michelet.reservation.application.reservation.result.ReservationCourseResult;
@@ -15,28 +17,66 @@ import com.michelet.reservation.domain.repository.ReservationRepository;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class ReservationQueryServiceImpl implements ReservationQueryService {
 
     private final ReservationRepository reservationRepository;
     private final ReservationCourseRepository reservationCourseRepository;
+    private final CacheManager cacheManager;
 
+    // @Cacheable이 캐시 히트 시 @Transactional 어드바이스(커넥션 획득)를 건너뛰도록
+    // 클래스 레벨이 아닌 메서드 레벨에 선언한다.
+    //
+    // getList()는 Page<T>를 직접 캐싱하지 않는다.
+    // PageImpl에 @JsonCreator가 없어 GenericJackson2JsonRedisSerializer가 역직렬화에 실패하므로
+    // non-final 래퍼 클래스 CachedListPage에 content + totalElements만 저장하고
+    // 캐시 히트 시 PageImpl로 재조립한다.
     @Override
+    @Transactional(readOnly = true)
     public Page<ReservationSummaryResult> getList(UUID userId, ReservationStatus status, Pageable pageable) {
+        String key = userId.toString() + ':' + (status != null ? status.name() : "ALL")
+                + ':' + pageable.getPageNumber() + ':' + pageable.getPageSize();
+        Cache listCache = cacheManager.getCache("reservation:list");
+
+        if (listCache != null) {
+            CachedListPage hit = listCache.get(key, CachedListPage.class);
+            if (hit != null) {
+                return new PageImpl<>(hit.content, pageable, hit.totalElements);
+            }
+        }
+
         Page<Reservation> page = (status != null)
                 ? reservationRepository.findPageByUserIdAndStatus(userId, status, pageable)
                 : reservationRepository.findPageByUserId(userId, pageable);
-        return page.map(ReservationSummaryResult::from);
+        List<ReservationSummaryResult> content = page.getContent().stream()
+                .map(ReservationSummaryResult::from)
+                .toList();
+        long total = page.getTotalElements();
+
+        if (listCache != null) {
+            listCache.put(key, new CachedListPage(content, total));
+        }
+
+        return new PageImpl<>(content, pageable, total);
     }
 
     @Override
+    @Transactional(readOnly = true)
+    @Cacheable(
+            cacheNames = "reservation:detail",
+            key = "#reservationId.toString()"
+    )
     public ReservationResult getDetail(UUID userId, String userRole, UUID reservationId) {
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new BusinessException(ReservationErrorCode.RESERVATION_NOT_FOUND));
@@ -52,7 +92,9 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
         return ReservationResult.of(reservation, courses);
     }
 
+    // 이하 메서드는 서비스 간 정확성이 성능보다 중요하므로 캐싱 제외
     @Override
+    @Transactional(readOnly = true)
     public ReservationValidityResult checkValidity(UUID userId, UUID restaurantId) {
         return reservationRepository.findTopByUserIdAndRestaurantIdAndStatusInOrderByReservedDateDesc(
                         userId, restaurantId, List.of(ReservationStatus.CONFIRMED, ReservationStatus.COMPLETED))
@@ -61,6 +103,7 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ReservationExistsResult checkExists(UUID reservationId, UUID userId, UUID restaurantId) {
         boolean exists = reservationRepository.findById(reservationId)
                 .filter(r -> r.getUserId().equals(userId)
@@ -71,6 +114,7 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ReservationActiveResult hasActiveReservation(UUID userId) {
         boolean exists = reservationRepository.existsByUserIdAndStatus(userId, ReservationStatus.CONFIRMED);
         return exists ? ReservationActiveResult.found() : ReservationActiveResult.notFound();
@@ -84,6 +128,21 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
         // 현재 Feign 미구현 → fail-closed: OWNER도 userId 기반 검증 적용 (USER 동일 수준)
         if (!reservation.getUserId().equals(userId)) {
             throw new BusinessException(ReservationErrorCode.RESERVATION_NOT_FOUND);
+        }
+    }
+
+    // Page<T>를 직접 캐싱하면 PageImpl 역직렬화 실패 → content + total만 저장하는 래퍼.
+    // non-final class(record 아님)이어야 NON_FINAL typing이 @class를 삽입한다.
+    static class CachedListPage {
+        public final List<ReservationSummaryResult> content;
+        public final long totalElements;
+
+        @JsonCreator
+        CachedListPage(
+                @JsonProperty("content") List<ReservationSummaryResult> content,
+                @JsonProperty("totalElements") long totalElements) {
+            this.content = content;
+            this.totalElements = totalElements;
         }
     }
 }

--- a/src/main/java/com/michelet/reservation/application/reservation/ReservationQueryServiceImpl.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/ReservationQueryServiceImpl.java
@@ -22,7 +22,6 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/michelet/reservation/application/reservation/result/ReservationListCachePage.java
+++ b/src/main/java/com/michelet/reservation/application/reservation/result/ReservationListCachePage.java
@@ -1,0 +1,22 @@
+package com.michelet.reservation.application.reservation.result;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+// non-final class — NON_FINAL typing이 @class를 삽입할 수 있도록 record 대신 class 사용.
+// Redis 저장 시 @class 키에 이 클래스의 FQCN이 포함된다.
+// 이름 변경 시 기존 캐시 엔트리 역직렬화가 실패하므로, 이름을 안정적으로 유지할 것.
+public class ReservationListCachePage {
+
+    public final List<ReservationSummaryResult> content;
+    public final long totalElements;
+
+    @JsonCreator
+    public ReservationListCachePage(
+            @JsonProperty("content") List<ReservationSummaryResult> content,
+            @JsonProperty("totalElements") long totalElements) {
+        this.content = content;
+        this.totalElements = totalElements;
+    }
+}

--- a/src/main/java/com/michelet/reservation/config/DataSourceConfig.java
+++ b/src/main/java/com/michelet/reservation/config/DataSourceConfig.java
@@ -1,0 +1,31 @@
+package com.michelet.reservation.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@Configuration
+public class DataSourceConfig {
+
+    // spring.datasource.hikari.* 전체 바인딩 — application.yaml의 pool 설정 유지
+    @Bean
+    @ConfigurationProperties("spring.datasource.hikari")
+    public HikariDataSource hikariDataSource(DataSourceProperties properties) {
+        return properties.initializeDataSourceBuilder()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    // @Transactional 진입 시 커넥션 획득을 첫 SQL 실행 시점까지 지연.
+    // getList() 캐시 히트 경로에서 SQL 없이 반환되면 HikariCP 커넥션을 획득하지 않는다.
+    @Bean
+    @Primary
+    public DataSource dataSource(HikariDataSource hikariDataSource) {
+        return new LazyConnectionDataSourceProxy(hikariDataSource);
+    }
+}

--- a/src/main/java/com/michelet/reservation/config/RedisCacheConfig.java
+++ b/src/main/java/com/michelet/reservation/config/RedisCacheConfig.java
@@ -9,7 +9,10 @@ import com.michelet.reservation.application.reservation.result.ReservationCourse
 import com.michelet.reservation.application.reservation.result.ReservationResult;
 import com.michelet.reservation.application.reservation.result.ReservationSummaryResult;
 import java.time.Duration;
+import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.cache.interceptor.SimpleCacheErrorHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -21,17 +24,21 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableCaching
-public class RedisCacheConfig {
+public class RedisCacheConfig implements CachingConfigurer {
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
         ObjectMapper objectMapper = new ObjectMapper()
                 .registerModule(new JavaTimeModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                // NON_FINAL: non-final 타입에 @class 포함 → 역직렬화 시 정확한 타입 복원
+                // NON_FINAL: non-final 타입에 @class 포함 → 역직렬화 시 정확한 타입 복원.
+                // allowlist를 com.michelet.reservation + java.util.List(및 구현체)로 한정해
+                // Jackson gadget 공격 위험을 줄인다.
+                // record(final) 타입은 mix-in @JsonTypeInfo로 별도 처리하므로 validator 범위 불필요.
                 .activateDefaultTyping(
                         BasicPolymorphicTypeValidator.builder()
-                                .allowIfSubType(Object.class)
+                                .allowIfSubType("com.michelet.reservation.")
+                                .allowIfSubType(java.util.List.class)
                                 .build(),
                         ObjectMapper.DefaultTyping.NON_FINAL,
                         JsonTypeInfo.As.PROPERTY
@@ -61,6 +68,13 @@ public class RedisCacheConfig {
                 .withCacheConfiguration("reservation:detail",
                         defaultConfig.entryTtl(Duration.ofSeconds(60)))
                 .build();
+    }
+
+    // Redis 오류(직렬화 실패, 연결 끊김 등)를 WARN 로그로 남기고 예외를 삼킴.
+    // 캐시 오류가 500으로 전파되지 않고 실제 메서드(DB 조회)로 fallback된다.
+    @Override
+    public CacheErrorHandler errorHandler() {
+        return new SimpleCacheErrorHandler();
     }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")

--- a/src/main/java/com/michelet/reservation/config/RedisCacheConfig.java
+++ b/src/main/java/com/michelet/reservation/config/RedisCacheConfig.java
@@ -1,0 +1,68 @@
+package com.michelet.reservation.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.michelet.reservation.application.reservation.result.ReservationCourseResult;
+import com.michelet.reservation.application.reservation.result.ReservationResult;
+import com.michelet.reservation.application.reservation.result.ReservationSummaryResult;
+import java.time.Duration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        ObjectMapper objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                // NON_FINAL: non-final 타입에 @class 포함 → 역직렬화 시 정확한 타입 복원
+                .activateDefaultTyping(
+                        BasicPolymorphicTypeValidator.builder()
+                                .allowIfSubType(Object.class)
+                                .build(),
+                        ObjectMapper.DefaultTyping.NON_FINAL,
+                        JsonTypeInfo.As.PROPERTY
+                );
+
+        // Java record는 암묵적으로 final → NON_FINAL typing이 @class를 삽입하지 않는다.
+        // Mix-in으로 @JsonTypeInfo를 명시 적용해 캐시 저장 시 class 정보를 포함시킨다.
+        objectMapper.addMixIn(ReservationResult.class, TypedMixin.class);
+        objectMapper.addMixIn(ReservationCourseResult.class, TypedMixin.class);
+        objectMapper.addMixIn(ReservationSummaryResult.class, TypedMixin.class);
+
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofSeconds(60))
+                .disableCachingNullValues()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new GenericJackson2JsonRedisSerializer(objectMapper)));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultConfig)
+                // list: 30초 — 생성·취소가 반영되는 신선도 요구가 높음
+                .withCacheConfiguration("reservation:list",
+                        defaultConfig.entryTtl(Duration.ofSeconds(30)))
+                // detail: 60초 — 단건 조회는 변경 빈도가 낮음
+                .withCacheConfiguration("reservation:detail",
+                        defaultConfig.entryTtl(Duration.ofSeconds(60)))
+                .build();
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
+    abstract static class TypedMixin {}
+}

--- a/src/main/java/com/michelet/reservation/infrastructure/outbox/OutboxEventAdapter.java
+++ b/src/main/java/com/michelet/reservation/infrastructure/outbox/OutboxEventAdapter.java
@@ -85,6 +85,7 @@ public class OutboxEventAdapter implements OutboxEventPort {
     }
 
     @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void recordSlotReleased(UUID reservationId, UUID timeSlotId, int capacity,
                                    LocalDateTime occurredAt) {
         save(reservationId, AggregateType.RESERVATION, KafkaTopics.RESERVATION_SLOT_RELEASED,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,13 +14,16 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:create-drop}
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         default_schema: reservation_service
     show-sql: false
     open-in-view: false
+
+  cache:
+    type: redis
 
   data:
     redis:

--- a/src/test/java/com/michelet/reservation/application/reservation/ReservationCommandServiceTest.java
+++ b/src/test/java/com/michelet/reservation/application/reservation/ReservationCommandServiceTest.java
@@ -189,6 +189,8 @@ class ReservationCommandServiceTest {
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ReservationErrorCode.TIMESLOT_SERVICE_UNAVAILABLE.getCode()));
 
+            // 타임아웃은 실제 차감 여부 불확실 → voided 이벤트로 보상 보장
+            verify(outboxEventPort).recordReservationCreationVoided(any(), any(), anyInt(), any());
             verify(outboxEventPort, never()).recordReservationCreated(any(), any(), any(), any(), any(), anyInt(),
                     any());
             verify(outboxEventPort, never()).recordWaitingCompleted(any(), any(), any());
@@ -204,6 +206,8 @@ class ReservationCommandServiceTest {
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ReservationErrorCode.TIMESLOT_SERVICE_UNAVAILABLE.getCode()));
 
+            // 연결 오류도 차감 여부 불확실 → voided 이벤트로 보상 보장
+            verify(outboxEventPort).recordReservationCreationVoided(any(), any(), anyInt(), any());
             verify(outboxEventPort, never()).recordReservationCreated(any(), any(), any(), any(), any(), anyInt(),
                     any());
             verify(outboxEventPort, never()).recordWaitingCompleted(any(), any(), any());
@@ -454,6 +458,8 @@ class ReservationCommandServiceTest {
             assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED_PAID);
             verify(outboxEventPort).recordReservationCancelled(any(), any(), any(), any(), any(), anyInt(), any(),
                     any());
+            // Feign 실패 → outbox로 비동기 슬롯 복구 보장
+            verify(outboxEventPort).recordSlotReleased(any(), any(), anyInt(), any());
         }
 
         @Test
@@ -529,6 +535,8 @@ class ReservationCommandServiceTest {
 
             verify(reservationRepository).delete(eq(reservationId), eq(userId));
             verify(outboxEventPort).recordReservationDeleted(any(), any(), any(), any(), anyInt(), any());
+            // Feign 실패 → outbox로 비동기 슬롯 복구 보장
+            verify(outboxEventPort).recordSlotReleased(any(), any(), anyInt(), any());
         }
 
         @Test

--- a/src/test/java/com/michelet/reservation/application/reservation/ReservationQueryServiceTest.java
+++ b/src/test/java/com/michelet/reservation/application/reservation/ReservationQueryServiceTest.java
@@ -88,6 +88,9 @@ class ReservationQueryServiceTest {
         }
     }
 
+    // NOTE: @Cacheable AOP는 Spring 프록시에서 실행되므로 Mockito 단위 테스트에서는 동작하지 않는다.
+    // 캐시 히트 경로(authorization bypass 방지)는 통합 테스트에서 별도 검증 필요.
+    // 현재 테스트는 DB 경로(캐시 미스)의 비즈니스 로직만 검증한다.
     @Nested
     class GetDetail {
 

--- a/src/test/java/com/michelet/reservation/application/reservation/ReservationQueryServiceTest.java
+++ b/src/test/java/com/michelet/reservation/application/reservation/ReservationQueryServiceTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -40,6 +41,7 @@ class ReservationQueryServiceTest {
 
     @Mock ReservationRepository reservationRepository;
     @Mock ReservationCourseRepository reservationCourseRepository;
+    @Mock CacheManager cacheManager;
 
     @InjectMocks ReservationQueryServiceImpl queryService;
 


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
  R1 부하 테스트(150 VU, sleep 0.1s)에서 HikariCP 30개 풀이 포화되어
  list/detail p(95)가 503ms/598ms로 임계값(300ms)을 위반했다.
  DB 도달 건수를 줄이는 Redis 캐싱으로 근본 원인을 해소하고,
  구현 과정에서 식별된 안정성·보안 문제를 함께 수정했다.


## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #57   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.
<img width="2356" height="296" alt="image" src="https://github.com/user-attachments/assets/5f5db131-aa6b-4b3f-a056-fbe1a9bc279c" />
<img width="2" height="1" alt="image" src="https://github.com/user-attachments/assets/5993c510-b8d1-4bac-9de1-e2712c5f200d" />

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 예약 조회 및 목록 조회 성능 최적화로 더 빠른 응답 속도 제공

* **안정성 강화**
  * 예약 생성, 수정, 취소, 삭제 시 데이터 일관성 강화
  * 슬롯 복구 실패 상황에 대한 신뢰성 있는 처리 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/reservation-service/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->